### PR TITLE
feat(shared,api): types, schemas, prompt template

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,2 @@
+export * from './routes.js'
+export * from './types.js'

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -1,0 +1,85 @@
+// HTTP route schemas. The conductor and the dashboard both import these so
+// they cannot drift on request/response shapes. Each route gets:
+//   - method, path constants
+//   - input schema (params, query, body, as relevant)
+//   - output schema
+//
+// Routes here are placeholders for Phase 0; concrete handlers live in the
+// conductor and consume these schemas via .parse().
+
+import { z } from 'zod'
+import {
+  ProjectSchema,
+  SessionSchema,
+  PullRequestSchema,
+} from '@maestro/shared'
+
+// ─── Common ──────────────────────────────────────────────────────────
+
+export const HealthResponseSchema = z.object({
+  status: z.literal('ok'),
+  version: z.string(),
+  uptimeSeconds: z.number().nonnegative(),
+  timestamp: z.string().datetime(),
+})
+
+export const ErrorResponseSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    context: z.record(z.unknown()).optional(),
+  }),
+})
+
+// ─── /api/projects ───────────────────────────────────────────────────
+
+export const ListProjectsResponseSchema = z.object({
+  projects: z.array(ProjectSchema),
+})
+
+export const GetProjectParamsSchema = z.object({
+  slug: z.string().min(1),
+})
+
+export const GetProjectResponseSchema = z.object({
+  project: ProjectSchema,
+})
+
+// ─── /api/sessions ───────────────────────────────────────────────────
+
+export const ListSessionsQuerySchema = z.object({
+  projectId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(200).default(50),
+  offset: z.coerce.number().int().nonnegative().default(0),
+})
+
+export const ListSessionsResponseSchema = z.object({
+  sessions: z.array(SessionSchema),
+  total: z.number().int().nonnegative(),
+})
+
+// ─── /api/prs ────────────────────────────────────────────────────────
+
+export const ListPullRequestsQuerySchema = z.object({
+  projectId: z.string().min(1).optional(),
+  status: z.enum(['draft', 'open', 'merged', 'closed', 'needs-review']).optional(),
+})
+
+export const ListPullRequestsResponseSchema = z.object({
+  pullRequests: z.array(PullRequestSchema),
+})
+
+// ─── Route registry ──────────────────────────────────────────────────
+
+// A typed catalogue of every route, useful to the dashboard's fetch wrapper
+// for path lookup and to the conductor for documentation. Add new entries
+// here when adding routes.
+export const ROUTES = {
+  health: { method: 'GET', path: '/api/health' },
+  listProjects: { method: 'GET', path: '/api/projects' },
+  getProject: { method: 'GET', path: '/api/projects/:slug' },
+  listSessions: { method: 'GET', path: '/api/sessions' },
+  listPullRequests: { method: 'GET', path: '/api/prs' },
+} as const
+
+export type RouteKey = keyof typeof ROUTES

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,0 +1,28 @@
+// Types derived from the Zod schemas in ./routes.ts. Import these on the
+// dashboard side for static checking; the conductor uses .parse() at runtime.
+
+import type { z } from 'zod'
+import type {
+  HealthResponseSchema,
+  ErrorResponseSchema,
+  ListProjectsResponseSchema,
+  GetProjectParamsSchema,
+  GetProjectResponseSchema,
+  ListSessionsQuerySchema,
+  ListSessionsResponseSchema,
+  ListPullRequestsQuerySchema,
+  ListPullRequestsResponseSchema,
+} from './routes.js'
+
+export type HealthResponse = z.infer<typeof HealthResponseSchema>
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>
+
+export type ListProjectsResponse = z.infer<typeof ListProjectsResponseSchema>
+export type GetProjectParams = z.infer<typeof GetProjectParamsSchema>
+export type GetProjectResponse = z.infer<typeof GetProjectResponseSchema>
+
+export type ListSessionsQuery = z.infer<typeof ListSessionsQuerySchema>
+export type ListSessionsResponse = z.infer<typeof ListSessionsResponseSchema>
+
+export type ListPullRequestsQuery = z.infer<typeof ListPullRequestsQuerySchema>
+export type ListPullRequestsResponse = z.infer<typeof ListPullRequestsResponseSchema>

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,0 +1,75 @@
+// System-wide constants. Anything that's a tunable default for sessions, the
+// scheduler, or quality gates lives here so it has one canonical home.
+
+import type { ProjectAutonomyConfig, QualityGate } from './types.js'
+
+// ─── Prompt versioning ───────────────────────────────────────────────
+
+// The prompt template version. Bump on every meaningful change to
+// SESSION_PROMPT_TEMPLATE_V1 in prompt-templates.ts. See PROMPT_DESIGN.md.
+export const PROMPT_VERSION = '1.0.0'
+
+// ─── Time budgets (seconds) ──────────────────────────────────────────
+
+// Default hard kill ceiling for a session. ADR-007. 45 min.
+export const DEFAULT_TIME_BUDGET_SECONDS = 45 * 60
+
+// Wrap-up grace period — the agent is told to start finishing this many
+// seconds before the hard kill. Surfaces inside the prompt template.
+export const WRAP_UP_GRACE_SECONDS = 5 * 60
+
+// SIGTERM-to-SIGKILL window when killing a runaway process. ADR-007.
+export const KILL_GRACE_SECONDS = 30
+
+// Quality-gate-failed recovery turn budget. PROMPT_DESIGN.md "Special Cases".
+export const FIXUP_TURN_BUDGET_SECONDS = 15 * 60
+
+// ─── Defaults for new project autonomy config ────────────────────────
+
+export const DEFAULT_QUALITY_GATES: QualityGate[] = ['test', 'lint', 'typecheck']
+
+export const DEFAULT_AUTONOMY_CONFIG: ProjectAutonomyConfig = {
+  level: 'pr-only',
+  schedule: '0 */6 * * *',
+  timeBudget: DEFAULT_TIME_BUDGET_SECONDS,
+  qualityGates: DEFAULT_QUALITY_GATES,
+  branches: {
+    base: 'main',
+    prefix: 'maestro/',
+  },
+  github: {
+    prLabels: ['maestro'],
+    draftByDefault: false,
+  },
+  skipDays: [],
+  maxSessionsPerDay: 6,
+}
+
+// ─── Scheduling ──────────────────────────────────────────────────────
+
+// Global ceiling on simultaneously-running sessions across all projects.
+// Per-project concurrency is always 1 (ADR-008).
+export const MAX_CONCURRENT_SESSIONS = 3
+
+// ─── Layout ──────────────────────────────────────────────────────────
+
+// Where the .maestro/ directory lives inside each managed project.
+export const MAESTRO_DIR_NAME = '.maestro'
+
+// Subpaths within .maestro/.
+export const MAESTRO_PATHS = {
+  state: 'state.md',
+  context: 'context.md',
+  decisions: 'decisions.md',
+  autonomy: 'autonomy.json',
+  journal: 'journal',
+} as const
+
+// How many recent journal entries to surface in a session prompt.
+export const JOURNAL_LOOKBACK_ENTRIES = 3
+
+// ─── HTTP ────────────────────────────────────────────────────────────
+
+export const DEFAULT_PORT = 3000
+
+export const DEFAULT_DATA_DIR = './data'

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,108 @@
+// MaestroError — structured error with code + context, per AGENTS.md error
+// handling pattern.
+//
+//   throw new MaestroError('SESSION_SPAWN_FAILED', {
+//     cause: err,
+//     context: { project: project.slug, timeBudget, attempt },
+//   })
+
+export type MaestroErrorCode =
+  | 'SESSION_SPAWN_FAILED'
+  | 'SESSION_TIMEOUT'
+  | 'SESSION_KILLED'
+  | 'STATE_PARSE_FAILED'
+  | 'STATE_WRITE_FAILED'
+  | 'CONTEXT_FILE_MISSING'
+  | 'AUTONOMY_CONFIG_INVALID'
+  | 'QUALITY_GATE_FAILED'
+  | 'GIT_OPERATION_FAILED'
+  | 'GITHUB_API_FAILED'
+  | 'TELEGRAM_API_FAILED'
+  | 'DB_MIGRATION_FAILED'
+  | 'CONFIG_VALIDATION_FAILED'
+  | 'PROJECT_NOT_FOUND'
+  | 'PROJECT_LOCKED'
+  | 'INTERNAL_ERROR'
+
+export interface MaestroErrorOptions {
+  cause?: unknown
+  context?: Record<string, unknown>
+  message?: string
+}
+
+export class MaestroError extends Error {
+  readonly code: MaestroErrorCode
+  readonly context: Record<string, unknown>
+  override readonly cause: unknown
+
+  constructor(code: MaestroErrorCode, options: MaestroErrorOptions = {}) {
+    const message = options.message ?? defaultMessageFor(code)
+    super(message)
+    this.name = 'MaestroError'
+    this.code = code
+    this.context = options.context ?? {}
+    this.cause = options.cause
+    // Restore prototype chain when targeting older runtimes that don't preserve
+    // it through Error subclassing.
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      context: this.context,
+      cause: serializeCause(this.cause),
+      stack: this.stack,
+    }
+  }
+}
+
+function defaultMessageFor(code: MaestroErrorCode): string {
+  switch (code) {
+    case 'SESSION_SPAWN_FAILED':
+      return 'Failed to spawn Claude Code session'
+    case 'SESSION_TIMEOUT':
+      return 'Session exceeded its time budget'
+    case 'SESSION_KILLED':
+      return 'Session was killed before completion'
+    case 'STATE_PARSE_FAILED':
+      return 'Failed to parse .maestro/state.md'
+    case 'STATE_WRITE_FAILED':
+      return 'Failed to write .maestro/ state file'
+    case 'CONTEXT_FILE_MISSING':
+      return '.maestro/context.md is missing'
+    case 'AUTONOMY_CONFIG_INVALID':
+      return '.maestro/autonomy.json failed validation'
+    case 'QUALITY_GATE_FAILED':
+      return 'One or more quality gates failed'
+    case 'GIT_OPERATION_FAILED':
+      return 'Git operation failed'
+    case 'GITHUB_API_FAILED':
+      return 'GitHub API request failed'
+    case 'TELEGRAM_API_FAILED':
+      return 'Telegram API request failed'
+    case 'DB_MIGRATION_FAILED':
+      return 'Database migration failed'
+    case 'CONFIG_VALIDATION_FAILED':
+      return 'Configuration failed validation'
+    case 'PROJECT_NOT_FOUND':
+      return 'Project not found'
+    case 'PROJECT_LOCKED':
+      return 'Project is locked by another running session'
+    case 'INTERNAL_ERROR':
+      return 'Internal error'
+  }
+}
+
+function serializeCause(cause: unknown): unknown {
+  if (cause instanceof Error) {
+    return { name: cause.name, message: cause.message, stack: cause.stack }
+  }
+  return cause
+}
+
+export function isMaestroError(err: unknown): err is MaestroError {
+  return err instanceof MaestroError
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js'
+export * from './schemas.js'
+export * from './constants.js'
+export * from './prompt-templates.js'
+export * from './errors.js'

--- a/packages/shared/src/prompt-templates.ts
+++ b/packages/shared/src/prompt-templates.ts
@@ -1,0 +1,311 @@
+// Maestro session prompt templates.
+//
+// This is the most important file in the system. The text here directly drives
+// agent behavior on every managed project. Treat changes here with the same
+// rigor as production code: bump PROMPT_VERSION on any change, document the
+// reasoning in DECISIONS.md, and dry-run before deploying. See PROMPT_DESIGN.md.
+
+import { PROMPT_VERSION, WRAP_UP_GRACE_SECONDS } from './constants.js'
+import type { ProjectAutonomyConfig, QualityGate } from './types.js'
+
+// ─── Public API ──────────────────────────────────────────────────────
+
+export interface SessionPromptContext {
+  /** Human-readable project name. */
+  projectName: string
+  /** Slug used for branch naming (e.g. "tripkaptan"). */
+  projectSlug: string
+  /** Hard kill ceiling for this session, in seconds. */
+  timeBudgetSeconds: number
+  /** Git config user.name, surfaced in the prompt to prevent agent re-config. */
+  developerName: string
+  /** Full markdown body of .maestro/context.md. */
+  context: string
+  /** Full markdown body of .maestro/state.md. */
+  state: string
+  /** Recent journal entries, oldest first. Empty array on a fresh project. */
+  recentJournal: Array<{ filename: string; body: string }>
+  /** Concrete task derived from state.md "Next Concrete Tasks". */
+  task: string
+  /** Quality gates that will run after commit. */
+  qualityGates: QualityGate[]
+  /** Project-specific never-touch list, drawn from context.md. */
+  projectSpecificNeverTouch?: string[]
+  /** True when .maestro/journal/ is empty for this project. */
+  isFirstSession?: boolean
+  /** Days since the last session. Used for the "long pause" preamble. */
+  daysSinceLastSession?: number
+  /** Recent developer commits in last 24h, if any. Triggers caution preamble. */
+  recentDeveloperCommits?: string
+}
+
+export interface FixupTurnPromptContext {
+  projectName: string
+  /** The output of the failing quality gates, included verbatim. */
+  failureOutput: string
+  /** Fixup turn budget in seconds. Default 15 min via FIXUP_TURN_BUDGET_SECONDS. */
+  timeBudgetSeconds: number
+}
+
+export function buildSessionPrompt(ctx: SessionPromptContext): string {
+  const minutes = Math.round(ctx.timeBudgetSeconds / 60)
+  const wrapMinutes = Math.max(1, Math.round((ctx.timeBudgetSeconds - WRAP_UP_GRACE_SECONDS) / 60))
+
+  const journalSection = ctx.recentJournal.length
+    ? ctx.recentJournal
+        .map((entry) => `### ${entry.filename}\n\n${entry.body.trim()}`)
+        .join('\n\n')
+    : '_(No prior sessions on this project.)_'
+
+  const gatesSection = ctx.qualityGates.length
+    ? ctx.qualityGates.map((g) => `   - \`${g}\``).join('\n')
+    : '   _(none configured)_'
+
+  const projectNeverList = (ctx.projectSpecificNeverTouch ?? [])
+    .map((item) => `   - ${item}`)
+    .join('\n')
+
+  const preamble = buildPreamble(ctx)
+
+  return SESSION_PROMPT_TEMPLATE_V1({
+    projectName: ctx.projectName,
+    projectSlug: ctx.projectSlug,
+    minutes,
+    wrapMinutes,
+    developerName: ctx.developerName,
+    context: ctx.context.trim(),
+    state: ctx.state.trim(),
+    journalSection,
+    task: ctx.task.trim(),
+    gatesSection,
+    projectNeverList,
+    preamble,
+    promptVersion: PROMPT_VERSION,
+  })
+}
+
+export function buildFixupTurnPrompt(ctx: FixupTurnPromptContext): string {
+  const minutes = Math.round(ctx.timeBudgetSeconds / 60)
+  return FIXUP_TURN_TEMPLATE_V1({
+    projectName: ctx.projectName,
+    minutes,
+    failureOutput: ctx.failureOutput.trim(),
+  })
+}
+
+// ─── Templates ───────────────────────────────────────────────────────
+
+interface SessionTemplateInputs {
+  projectName: string
+  projectSlug: string
+  minutes: number
+  wrapMinutes: number
+  developerName: string
+  context: string
+  state: string
+  journalSection: string
+  task: string
+  gatesSection: string
+  projectNeverList: string
+  preamble: string
+  promptVersion: string
+}
+
+const SESSION_PROMPT_TEMPLATE_V1 = (i: SessionTemplateInputs): string =>
+  `You are an autonomous developer working on the project: ${i.projectName}.
+
+Your time budget: ${i.minutes} minutes. At ${i.wrapMinutes} minutes, begin
+wrapping up cleanly. At ${i.minutes} minutes, your process will be killed.
+
+You are working in a fresh checkout of the main branch. The git identity is
+already configured to ${i.developerName}. All commits will appear under the
+developer's name.
+${i.preamble}
+== PROJECT CONTEXT ==
+
+${i.context || '_(context.md is empty — note this in your journal entry.)_'}
+
+== CURRENT STATE ==
+
+${i.state || '_(state.md is empty — note this in your journal entry.)_'}
+
+== RECENT JOURNAL (last 3 sessions) ==
+
+${i.journalSection}
+
+== YOUR TASK ==
+
+${i.task || '_(No concrete task supplied. If state.md does not name one, do nothing and explain in the journal.)_'}
+
+== RULES ==
+
+1. Make focused progress. Pick ONE task from the list above. Don't try to do
+   multiple things in one session.
+
+2. If the task is unclear or doesn't make sense given the current code, DO NOT
+   guess. Write your concerns to the journal and stop. Empty sessions are fine.
+
+3. Quality gates will run after you commit:
+${i.gatesSection}
+   Your code must pass all of them. Run them yourself before committing.
+
+4. Follow the project's existing conventions:
+   - Code style (read context.md)
+   - Commit message format (read context.md)
+   - Testing patterns (read context.md)
+   - Don't introduce new dependencies without good reason
+
+5. Before finishing, you MUST:
+   a. Update .maestro/state.md to reflect what was done and what's next
+   b. Append a session summary to .maestro/journal/{timestamp}.md
+   c. Commit all changes (including .maestro/ updates) on a feature branch
+   d. The feature branch name should be: maestro/${i.projectSlug}/{short-description}
+
+6. Things you must NEVER touch without explicit state.md instruction:
+   - Authentication / authorization code
+   - Payment processing
+   - Production database migrations
+   - CI/CD configuration
+   - Environment variable handling
+   - Cryptography or security primitives
+${i.projectNeverList ? `\n${i.projectNeverList}` : ''}
+
+7. If you discover something important during the session that future sessions
+   need to know, add it to context.md (the long-lived context) — but only for
+   genuinely durable information, not session-specific notes.
+
+== JOURNAL ENTRY FORMAT ==
+
+When you append to the journal, use this format:
+
+\`\`\`
+# Session {ISO timestamp}
+
+## Goal
+{what you set out to do}
+
+## What I Did
+{narrative of the work, including reasoning}
+
+## What Worked
+{techniques or approaches that worked well}
+
+## What Didn't
+{dead ends, mistakes corrected, things that didn't work}
+
+## Quality Gates
+{which gates ran, results}
+
+## State Update
+{what you changed in state.md and why}
+
+## For Next Session
+{important context for the next agent that runs}
+
+## Cost
+{tokens used if available}
+\`\`\`
+
+== STATE.MD UPDATE FORMAT ==
+
+After your work, state.md should reflect:
+
+- The "Focus" section may stay the same or change slightly
+- The "Next Concrete Tasks" should have your task removed and possibly new
+  tasks added based on what you discovered
+- The "Blockers" section should be updated if you hit any
+- The "Recent Context" section should be 2-3 sentences about what just happened
+
+== BEGIN SESSION ==
+
+Start by acknowledging your task. Then proceed.
+
+[prompt-version: ${i.promptVersion}]
+`
+
+function buildPreamble(ctx: SessionPromptContext): string {
+  const parts: string[] = []
+
+  if (ctx.isFirstSession) {
+    parts.push(
+      [
+        '== FIRST SESSION ==',
+        '',
+        'This is the first Maestro session for this project. Before doing other work:',
+        '',
+        '1. Read the README.md and the package.json (or equivalent)',
+        '2. Explore the directory structure briefly',
+        '3. If context.md is sparse, expand it with what you have learned',
+        '4. Identify 3-5 candidate tasks for state.md "Next Concrete Tasks"',
+        '5. Don\'t make code changes in this first session — just observe and document',
+        '',
+        'The first session is for orientation. The next session will start work.',
+      ].join('\n'),
+    )
+  }
+
+  if (ctx.daysSinceLastSession !== undefined && ctx.daysSinceLastSession >= 14) {
+    parts.push(
+      [
+        '== LONG PAUSE ==',
+        '',
+        `This project has not had a Maestro session in ${ctx.daysSinceLastSession} days.`,
+        'Significant changes may have happened. Before starting work:',
+        '',
+        '1. Run `git log --since=...` to see recent commits',
+        '2. Read any new files or significantly changed files',
+        '3. Update context.md if architectural changes have happened',
+        '4. Update state.md if the focus seems stale',
+        '5. Then proceed with normal work',
+      ].join('\n'),
+    )
+  }
+
+  if (ctx.recentDeveloperCommits && ctx.recentDeveloperCommits.trim().length > 0) {
+    parts.push(
+      [
+        '== DEVELOPER WAS RECENTLY ACTIVE ==',
+        '',
+        'The developer has been actively working on this project. Recent commits:',
+        '',
+        '```',
+        ctx.recentDeveloperCommits.trim(),
+        '```',
+        '',
+        'Be especially careful not to undo or duplicate their work. If state.md',
+        'seems stale relative to their commits, update it before starting new work.',
+      ].join('\n'),
+    )
+  }
+
+  return parts.length ? `\n${parts.join('\n\n')}\n` : ''
+}
+
+interface FixupTemplateInputs {
+  projectName: string
+  minutes: number
+  failureOutput: string
+}
+
+const FIXUP_TURN_TEMPLATE_V1 = (i: FixupTemplateInputs): string =>
+  `Your previous session on ${i.projectName} committed changes, but quality gates failed:
+
+\`\`\`
+${i.failureOutput}
+\`\`\`
+
+You have ${i.minutes} minutes to fix the failures. Do not add new functionality.
+Only fix what's broken. Commit the fix, push, then exit.
+
+If you cannot fix it within ${i.minutes} minutes, exit cleanly. The branch will
+be left as-is for manual review.
+
+[prompt-version: ${PROMPT_VERSION}]
+`
+
+// Re-export under stable names so callers can reach the templates directly for
+// dry-run / debugging without going through buildSessionPrompt.
+export { SESSION_PROMPT_TEMPLATE_V1, FIXUP_TURN_TEMPLATE_V1 }
+
+// Convenience: also export a pre-baked default autonomy hint useful for tests.
+export const DEFAULT_AUTONOMY_LEVEL: ProjectAutonomyConfig['level'] = 'pr-only'

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,165 @@
+// Zod schemas — the runtime source of truth for every shape that crosses an
+// external boundary. Validate every external input with these.
+//
+// Per AGENTS.md: never trust state from .maestro/ files, GitHub responses, or
+// API payloads without parsing through one of these.
+
+import { z } from 'zod'
+
+// ─── Autonomy ────────────────────────────────────────────────────────
+
+export const ProjectAutonomyLevelSchema = z.enum(['full', 'pr-only', 'draft-only', 'paused'])
+
+export const QualityGateNameSchema = z.enum(['test', 'lint', 'typecheck', 'build'])
+
+export const QualityGateStatusSchema = z.enum(['passed', 'failed', 'skipped'])
+
+export const ProjectAutonomyConfigSchema = z.object({
+  level: ProjectAutonomyLevelSchema,
+  // Standard cron expression. Validated as a non-empty string here; the
+  // scheduler validates parseability when it loads the config.
+  schedule: z.string().min(1),
+  // Hard kill ceiling for a session, in seconds. See ADR-007.
+  timeBudget: z.number().int().positive(),
+  qualityGates: z.array(QualityGateNameSchema),
+  branches: z.object({
+    base: z.string().min(1).default('main'),
+    prefix: z.string().min(1).default('maestro/'),
+  }),
+  github: z.object({
+    prLabels: z.array(z.string()).default([]),
+    draftByDefault: z.boolean().default(false),
+  }),
+  skipDays: z.array(z.string()).default([]),
+  maxSessionsPerDay: z.number().int().positive().default(6),
+})
+
+// ─── Project ─────────────────────────────────────────────────────────
+
+export const ProjectSchema = z.object({
+  id: z.string().min(1),
+  slug: z.string().min(1),
+  repoUrl: z.string().url(),
+  autonomyConfig: ProjectAutonomyConfigSchema,
+  createdAt: z.string().datetime(),
+})
+
+// ─── Sessions & quality gates ────────────────────────────────────────
+
+export const SessionStatusSchema = z.enum([
+  'pending',
+  'running',
+  'completed',
+  'completed-no-changes',
+  'quality-gate-failed',
+  'timed-out',
+  'failed',
+  'cancelled',
+])
+
+export const QualityGateRunSchema = z.object({
+  id: z.string().min(1).optional(),
+  sessionId: z.string().min(1),
+  gateName: QualityGateNameSchema,
+  status: QualityGateStatusSchema,
+  output: z.string(),
+  ranAt: z.string().datetime(),
+  durationMs: z.number().int().nonnegative().optional(),
+})
+
+export const SessionSchema = z.object({
+  id: z.string().min(1),
+  projectId: z.string().min(1),
+  status: SessionStatusSchema,
+  startedAt: z.string().datetime(),
+  endedAt: z.string().datetime().nullable(),
+  costCents: z.number().int().nonnegative().nullable(),
+  promptVersion: z.string().min(1),
+  branchName: z.string().nullable(),
+  prNumber: z.number().int().positive().nullable(),
+  journalPath: z.string().nullable(),
+})
+
+export const SessionResultSchema = z.object({
+  sessionId: z.string().min(1),
+  status: SessionStatusSchema,
+  filesChanged: z.array(z.string()),
+  commitSha: z.string().nullable(),
+  branchName: z.string().nullable(),
+  prNumber: z.number().int().positive().nullable(),
+  qualityGates: z.array(QualityGateRunSchema),
+  costCents: z.number().int().nonnegative().nullable(),
+  journalPath: z.string().nullable(),
+  notes: z.string().nullable(),
+})
+
+// ─── .maestro/ file contents ─────────────────────────────────────────
+
+// state.md and context.md are markdown by convention; they're not parsed into
+// strict structure by Maestro itself. The agent reads them, the developer
+// writes them. We keep them as strings here.
+
+export const ProjectStateSchema = z.object({
+  // The full markdown body of state.md. Sections are convention, not enforced.
+  raw: z.string(),
+  // The path the file was read from, relative to the project root.
+  path: z.string().default('.maestro/state.md'),
+})
+
+export const JournalEntrySchema = z.object({
+  // Filename like "2026-04-15-08-00.md" — the timestamp slug.
+  filename: z.string().regex(/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.md$/),
+  sessionId: z.string().min(1).nullable(),
+  // ISO timestamp parsed from the filename.
+  timestamp: z.string().datetime(),
+  // The full markdown body.
+  body: z.string(),
+})
+
+// ─── Pull requests ───────────────────────────────────────────────────
+
+export const PRStatusSchema = z.enum(['draft', 'open', 'merged', 'closed', 'needs-review'])
+
+export const PullRequestSchema = z.object({
+  number: z.number().int().positive(),
+  url: z.string().url(),
+  title: z.string().min(1),
+  body: z.string(),
+  status: PRStatusSchema,
+  branchName: z.string().min(1),
+  baseBranch: z.string().min(1),
+  createdAt: z.string().datetime(),
+  mergedAt: z.string().datetime().nullable(),
+  sessionId: z.string().min(1).nullable(),
+})
+
+// ─── Cost tracking ───────────────────────────────────────────────────
+
+export const CostRecordSchema = z.object({
+  id: z.string().min(1),
+  sessionId: z.string().min(1),
+  projectId: z.string().min(1),
+  // Cents — integers avoid floating point issues. Convert at presentation time.
+  costCents: z.number().int().nonnegative(),
+  inputTokens: z.number().int().nonnegative().nullable(),
+  outputTokens: z.number().int().nonnegative().nullable(),
+  cacheReadTokens: z.number().int().nonnegative().nullable(),
+  cacheWriteTokens: z.number().int().nonnegative().nullable(),
+  recordedAt: z.string().datetime(),
+})
+
+// ─── Briefing ────────────────────────────────────────────────────────
+
+export const BriefingSchema = z.object({
+  id: z.string().min(1),
+  sentAt: z.string().datetime(),
+  content: z.string(),
+  tgMessageId: z.string().nullable(),
+})
+
+// ─── autonomy.json on disk ───────────────────────────────────────────
+
+// The shape stored at .maestro/autonomy.json in each managed project. Same
+// content as ProjectAutonomyConfigSchema; isolated alias so we can evolve the
+// on-disk format separately from the in-memory representation if needed.
+export const AutonomyFileSchema = ProjectAutonomyConfigSchema

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,76 @@
+// Shared domain types. The Zod schemas in ./schemas.ts are the runtime source
+// of truth for everything that crosses an external boundary (API requests,
+// .maestro/ file contents, GitHub responses). Types here are derived from
+// those schemas so the static and runtime views never drift.
+
+import type {
+  ProjectSchema,
+  ProjectAutonomyConfigSchema,
+  SessionSchema,
+  SessionResultSchema,
+  QualityGateRunSchema,
+  JournalEntrySchema,
+  ProjectStateSchema,
+  PullRequestSchema,
+  CostRecordSchema,
+  BriefingSchema,
+} from './schemas.js'
+import type { z } from 'zod'
+
+// ─── Autonomy ────────────────────────────────────────────────────────
+
+export const PROJECT_AUTONOMY_LEVELS = ['full', 'pr-only', 'draft-only', 'paused'] as const
+export type ProjectAutonomyLevel = (typeof PROJECT_AUTONOMY_LEVELS)[number]
+
+export type ProjectAutonomyConfig = z.infer<typeof ProjectAutonomyConfigSchema>
+
+// ─── Project ─────────────────────────────────────────────────────────
+
+export type Project = z.infer<typeof ProjectSchema>
+
+// ─── Sessions ────────────────────────────────────────────────────────
+
+export const SESSION_STATUSES = [
+  'pending',
+  'running',
+  'completed',
+  'completed-no-changes',
+  'quality-gate-failed',
+  'timed-out',
+  'failed',
+  'cancelled',
+] as const
+export type SessionStatus = (typeof SESSION_STATUSES)[number]
+
+export type Session = z.infer<typeof SessionSchema>
+export type SessionResult = z.infer<typeof SessionResultSchema>
+
+// ─── Quality gates ───────────────────────────────────────────────────
+
+export const QUALITY_GATE_NAMES = ['test', 'lint', 'typecheck', 'build'] as const
+export type QualityGate = (typeof QUALITY_GATE_NAMES)[number]
+
+export const QUALITY_GATE_STATUSES = ['passed', 'failed', 'skipped'] as const
+export type QualityGateStatus = (typeof QUALITY_GATE_STATUSES)[number]
+
+export type QualityGateRun = z.infer<typeof QualityGateRunSchema>
+
+// ─── .maestro/ file contents ─────────────────────────────────────────
+
+export type JournalEntry = z.infer<typeof JournalEntrySchema>
+export type ProjectState = z.infer<typeof ProjectStateSchema>
+
+// ─── Pull requests ───────────────────────────────────────────────────
+
+export const PR_STATUSES = ['draft', 'open', 'merged', 'closed', 'needs-review'] as const
+export type PRStatus = (typeof PR_STATUSES)[number]
+
+export type PullRequest = z.infer<typeof PullRequestSchema>
+
+// ─── Cost tracking ───────────────────────────────────────────────────
+
+export type CostRecord = z.infer<typeof CostRecordSchema>
+
+// ─── Briefing ────────────────────────────────────────────────────────
+
+export type Briefing = z.infer<typeof BriefingSchema>


### PR DESCRIPTION
## Summary
- `packages/shared` defines the entire Maestro domain model with Zod schemas as the runtime source of truth and TypeScript types derived from them
- `SESSION_PROMPT_TEMPLATE_V1` lands verbatim from PROMPT_DESIGN.md, exposed via `buildSessionPrompt(ctx)` for Phase 1 to consume
- `MaestroError` provides the structured-context error pattern from AGENTS.md
- `packages/api` re-exports route input/output schemas so the conductor and dashboard can never drift on shapes

## Notable choices
- `noUncheckedIndexedAccess` is on; schemas use `.nullable()` rather than `.optional()` for fields that come back NULL from SQLite
- Prompt template carries `PROMPT_VERSION = '1.0.0'` — every session log will record the version that produced it
- First-session / long-pause / developer-active preambles are conditional, generated by `buildPreamble()`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes with zero warnings
- [x] `pnpm --filter @maestro/shared build` and `--filter @maestro/api build` succeed

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)