### PR TITLE
feat(conductor): Hono server with SQLite + placeholder modules

### DIFF
--- a/packages/conductor/scripts/copy-migrations.mjs
+++ b/packages/conductor/scripts/copy-migrations.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Copy SQL migrations into dist/ so that the compiled server can find them at
+// runtime. tsc doesn't move non-.ts files; this is a one-line build step.
+
+import { cp, mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const src = resolve(here, '..', 'src', 'db', 'migrations')
+const dest = resolve(here, '..', 'dist', 'db', 'migrations')
+
+await mkdir(dest, { recursive: true })
+await cp(src, dest, { recursive: true })
+console.log(`Copied migrations: ${src} → ${dest}`)

--- a/packages/conductor/src/briefing.ts
+++ b/packages/conductor/src/briefing.ts
@@ -1,0 +1,15 @@
+// Daily briefing generator + Telegram delivery. Phase 4 work (see
+// PRODUCT_VISION.md "Phase 4: Telegram Briefing"). The Phase 0 file is a stub.
+
+import type Database from 'better-sqlite3'
+import type { Config } from './config.js'
+import { logger } from './logger.js'
+
+export interface BriefingDeps {
+  db: Database.Database
+  config: Config
+}
+
+export function startBriefing(_deps: BriefingDeps): void {
+  logger.debug('briefing stub initialised (Phase 4 implementation pending)')
+}

--- a/packages/conductor/src/config.ts
+++ b/packages/conductor/src/config.ts
@@ -1,0 +1,66 @@
+// Runtime configuration loaded from environment variables. Validated with
+// Zod at startup so the conductor refuses to boot with bad config.
+
+import { config as loadDotenv } from 'dotenv'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { z } from 'zod'
+import { DEFAULT_DATA_DIR, DEFAULT_PORT, MaestroError } from '@maestro/shared'
+
+// Walk up from cwd looking for a .env so that running the conductor from
+// inside packages/conductor still picks up the repo-root .env in development.
+loadEnvFile()
+
+function loadEnvFile(): void {
+  let dir = process.cwd()
+  for (let i = 0; i < 6; i++) {
+    const candidate = resolve(dir, '.env')
+    if (existsSync(candidate)) {
+      loadDotenv({ path: candidate })
+      return
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return
+    dir = parent
+  }
+}
+
+const ConfigSchema = z.object({
+  port: z.coerce.number().int().positive().default(DEFAULT_PORT),
+  dataDir: z.string().min(1).default(DEFAULT_DATA_DIR),
+  developerName: z.string().min(1),
+  developerEmail: z.string().email().optional(),
+  developerGithubUsername: z.string().min(1),
+  // Optional in Phase 0; required when their respective subsystems come online.
+  githubToken: z.string().optional(),
+  telegramBotToken: z.string().optional(),
+  telegramChatId: z.string().optional(),
+  anthropicApiKey: z.string().optional(),
+  nodeEnv: z.enum(['development', 'production', 'test']).default('development'),
+})
+
+export type Config = z.infer<typeof ConfigSchema>
+
+export function loadConfig(): Config {
+  const parsed = ConfigSchema.safeParse({
+    port: process.env.MAESTRO_PORT,
+    dataDir: process.env.MAESTRO_DATA_DIR,
+    developerName: process.env.DEVELOPER_NAME,
+    developerEmail: process.env.DEVELOPER_EMAIL || undefined,
+    developerGithubUsername: process.env.DEVELOPER_GITHUB_USERNAME,
+    githubToken: process.env.GITHUB_TOKEN || undefined,
+    telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
+    telegramChatId: process.env.TELEGRAM_CHAT_ID || undefined,
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY || undefined,
+    nodeEnv: process.env.NODE_ENV,
+  })
+
+  if (!parsed.success) {
+    throw new MaestroError('CONFIG_VALIDATION_FAILED', {
+      message: 'Environment variables failed validation. See .env.example.',
+      context: { issues: parsed.error.issues },
+    })
+  }
+
+  return parsed.data
+}

--- a/packages/conductor/src/db.ts
+++ b/packages/conductor/src/db.ts
@@ -1,0 +1,101 @@
+// SQLite layer. Opens the database file under MAESTRO_DATA_DIR, runs every
+// pending migration in lexicographic order, and exposes the prepared `Database`
+// handle to the rest of the conductor.
+//
+// See ADR-003 for why SQLite. Schema lives in src/db/migrations/.
+
+import Database from 'better-sqlite3'
+import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { MaestroError } from '@maestro/shared'
+import { logger } from './logger.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+export interface DbHandle {
+  db: Database.Database
+  close: () => void
+}
+
+export interface OpenDbOptions {
+  /** Directory in which to store maestro.db. Created if missing. */
+  dataDir: string
+  /** Override the migrations directory. Defaults to <here>/db/migrations. */
+  migrationsDir?: string
+  /** When true, opens an in-memory db. Used in tests. */
+  memory?: boolean
+}
+
+export function openDatabase(options: OpenDbOptions): DbHandle {
+  const dbPath = options.memory ? ':memory:' : resolveDbPath(options.dataDir)
+  const db = new Database(dbPath)
+  db.pragma('foreign_keys = ON')
+  db.pragma('journal_mode = WAL')
+
+  ensureMigrationsTable(db)
+  applyPendingMigrations(db, options.migrationsDir ?? defaultMigrationsDir())
+
+  logger.info({ dbPath }, 'database opened')
+
+  return {
+    db,
+    close: () => db.close(),
+  }
+}
+
+function resolveDbPath(dataDir: string): string {
+  const dir = resolve(dataDir)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  return join(dir, 'maestro.db')
+}
+
+function defaultMigrationsDir(): string {
+  return join(here, 'db', 'migrations')
+}
+
+function ensureMigrationsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id          TEXT PRIMARY KEY,
+      applied_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    );
+  `)
+}
+
+function applyPendingMigrations(db: Database.Database, migrationsDir: string): void {
+  if (!existsSync(migrationsDir)) {
+    throw new MaestroError('DB_MIGRATION_FAILED', {
+      message: `Migrations directory not found: ${migrationsDir}`,
+      context: { migrationsDir },
+    })
+  }
+
+  const files = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+
+  const appliedRows = db
+    .prepare<[], { id: string }>('SELECT id FROM schema_migrations')
+    .all()
+  const applied = new Set(appliedRows.map((r) => r.id))
+
+  for (const file of files) {
+    if (applied.has(file)) continue
+    const sql = readFileSync(join(migrationsDir, file), 'utf-8')
+    const tx = db.transaction(() => {
+      db.exec(sql)
+      db.prepare('INSERT INTO schema_migrations (id) VALUES (?)').run(file)
+    })
+    try {
+      tx()
+      logger.info({ migration: file }, 'applied migration')
+    } catch (err) {
+      throw new MaestroError('DB_MIGRATION_FAILED', {
+        message: `Failed to apply migration ${file}`,
+        cause: err,
+        context: { migration: file },
+      })
+    }
+  }
+}

--- a/packages/conductor/src/db/migrations/001_initial.sql
+++ b/packages/conductor/src/db/migrations/001_initial.sql
@@ -1,0 +1,65 @@
+-- Maestro initial schema.
+--
+-- See ADR-003: SQLite is for operational state (which sessions ran, when, what
+-- they cost). The .maestro/ files in each managed repo are the source of truth
+-- for project state — never duplicate that here.
+
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+-- Projects registered with Maestro.
+CREATE TABLE IF NOT EXISTS projects (
+  id                   TEXT PRIMARY KEY,
+  slug                 TEXT NOT NULL UNIQUE,
+  repo_url             TEXT NOT NULL,
+  autonomy_config_json TEXT NOT NULL,
+  created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Sessions: one per Claude Code spawn.
+CREATE TABLE IF NOT EXISTS sessions (
+  id              TEXT PRIMARY KEY,
+  project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  status          TEXT NOT NULL CHECK (status IN (
+                    'pending','running','completed','completed-no-changes',
+                    'quality-gate-failed','timed-out','failed','cancelled'
+                  )),
+  started_at      TEXT NOT NULL,
+  ended_at        TEXT,
+  cost_cents      INTEGER,
+  prompt_version  TEXT NOT NULL,
+  branch_name     TEXT,
+  pr_number       INTEGER,
+  journal_path    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_project_started
+  ON sessions(project_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status
+  ON sessions(status);
+
+-- Quality gate runs, one row per gate per session.
+CREATE TABLE IF NOT EXISTS quality_gate_runs (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  gate_name   TEXT NOT NULL CHECK (gate_name IN ('test','lint','typecheck','build')),
+  status      TEXT NOT NULL CHECK (status IN ('passed','failed','skipped')),
+  output      TEXT NOT NULL DEFAULT '',
+  duration_ms INTEGER,
+  ran_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_quality_gates_session
+  ON quality_gate_runs(session_id);
+
+-- Daily briefings sent to Telegram.
+CREATE TABLE IF NOT EXISTS briefings (
+  id             TEXT PRIMARY KEY,
+  sent_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  content        TEXT NOT NULL,
+  tg_message_id  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_briefings_sent_at
+  ON briefings(sent_at DESC);

--- a/packages/conductor/src/index.ts
+++ b/packages/conductor/src/index.ts
@@ -1,0 +1,49 @@
+// Conductor entry point. Loads config, opens the database, builds the Hono
+// app, and starts listening. Background subsystems (scheduler, briefing) hang
+// off this module once their phases land.
+
+import { serve } from '@hono/node-server'
+import { loadConfig } from './config.js'
+import { openDatabase } from './db.js'
+import { buildServer } from './server.js'
+import { logger } from './logger.js'
+import { startScheduler } from './scheduler.js'
+import { startBriefing } from './briefing.js'
+
+const PACKAGE_VERSION = '0.0.0'
+
+async function main(): Promise<void> {
+  const config = loadConfig()
+  logger.info(
+    { port: config.port, dataDir: config.dataDir, env: config.nodeEnv },
+    'starting maestro conductor',
+  )
+
+  const dbHandle = openDatabase({ dataDir: config.dataDir })
+  const startedAt = Date.now()
+  const app = buildServer({ startedAt, version: PACKAGE_VERSION })
+
+  // Phase-deferred subsystems. These are no-ops in Phase 0 — they exist so
+  // wiring is in place for Phase 2 (scheduling) and Phase 4 (briefings).
+  startScheduler({ db: dbHandle.db, config })
+  startBriefing({ db: dbHandle.db, config })
+
+  const server = serve({ fetch: app.fetch, port: config.port }, (info) => {
+    logger.info({ address: info.address, port: info.port }, 'conductor listening')
+  })
+
+  const shutdown = (signal: string) => {
+    logger.info({ signal }, 'shutting down')
+    server.close(() => {
+      dbHandle.close()
+      process.exit(0)
+    })
+  }
+  process.on('SIGINT', () => shutdown('SIGINT'))
+  process.on('SIGTERM', () => shutdown('SIGTERM'))
+}
+
+main().catch((err) => {
+  logger.fatal({ err }, 'fatal startup error')
+  process.exit(1)
+})

--- a/packages/conductor/src/logger.ts
+++ b/packages/conductor/src/logger.ts
@@ -1,0 +1,27 @@
+// Pino logger. Use `logger.child({ ... })` to attach structured context per
+// session, project, or request. Never use console.log in conductor code.
+
+import pino from 'pino'
+
+const isDev = process.env.NODE_ENV !== 'production'
+const level = process.env.LOG_LEVEL ?? (isDev ? 'debug' : 'info')
+
+export const logger = pino({
+  level,
+  base: { service: 'maestro-conductor' },
+  timestamp: pino.stdTimeFunctions.isoTime,
+  ...(isDev
+    ? {
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+            translateTime: 'HH:MM:ss.l',
+            ignore: 'pid,hostname,service',
+          },
+        },
+      }
+    : {}),
+})
+
+export type Logger = typeof logger

--- a/packages/conductor/src/pr-manager.ts
+++ b/packages/conductor/src/pr-manager.ts
@@ -1,0 +1,21 @@
+// GitHub PR operations. Wraps Octokit. Phase 1 work (see PRODUCT_VISION.md
+// "Phase 1: Manual Single-Project Sessions"). The Phase 0 file is a stub.
+
+import type { Project, PullRequest } from '@maestro/shared'
+import { MaestroError } from '@maestro/shared'
+
+export interface OpenPullRequestInput {
+  project: Project
+  branchName: string
+  baseBranch: string
+  title: string
+  body: string
+  draft?: boolean
+  labels?: string[]
+}
+
+export async function openPullRequest(_input: OpenPullRequestInput): Promise<PullRequest> {
+  throw new MaestroError('INTERNAL_ERROR', {
+    message: 'openPullRequest is Phase 1 work. See PRODUCT_VISION.md.',
+  })
+}

--- a/packages/conductor/src/quality-gates.ts
+++ b/packages/conductor/src/quality-gates.ts
@@ -1,0 +1,21 @@
+// Quality gate runners. Phase 1 work (see PRODUCT_VISION.md). Per ADR-006:
+// gates run after the agent commits, before PR creation. If any gate fails,
+// the branch is preserved but no PR opens.
+
+import type { QualityGate, QualityGateRun } from '@maestro/shared'
+import { MaestroError } from '@maestro/shared'
+
+export interface RunQualityGatesInput {
+  /** Absolute path to the working checkout. */
+  projectRoot: string
+  sessionId: string
+  gates: QualityGate[]
+}
+
+export async function runQualityGates(
+  _input: RunQualityGatesInput,
+): Promise<QualityGateRun[]> {
+  throw new MaestroError('INTERNAL_ERROR', {
+    message: 'runQualityGates is Phase 1 work. See PRODUCT_VISION.md.',
+  })
+}

--- a/packages/conductor/src/scheduler.ts
+++ b/packages/conductor/src/scheduler.ts
@@ -1,0 +1,16 @@
+// Cron-based scheduler — Phase 2 work (see PRODUCT_VISION.md "Phase 2:
+// Scheduling and Parallelism"). In Phase 0 this is a no-op stub so wiring
+// from index.ts is already in place when the real implementation lands.
+
+import type Database from 'better-sqlite3'
+import type { Config } from './config.js'
+import { logger } from './logger.js'
+
+export interface SchedulerDeps {
+  db: Database.Database
+  config: Config
+}
+
+export function startScheduler(_deps: SchedulerDeps): void {
+  logger.debug('scheduler stub initialised (Phase 2 implementation pending)')
+}

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -1,0 +1,76 @@
+// Hono application setup. Routes return shapes defined in @maestro/api so the
+// dashboard always agrees with the conductor on types.
+//
+// Phase 0 routes are read-only stubs; Phase 1+ wires them to real data.
+
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { logger as honoLogger } from 'hono/logger'
+import { HTTPException } from 'hono/http-exception'
+import {
+  ListProjectsResponseSchema,
+  ListSessionsResponseSchema,
+  HealthResponseSchema,
+} from '@maestro/api'
+import { isMaestroError } from '@maestro/shared'
+import { logger } from './logger.js'
+
+export interface ServerDeps {
+  /** Best-effort uptime baseline for the /health response. */
+  startedAt: number
+  /** Package version surfaced in /health. */
+  version: string
+}
+
+export function buildServer(deps: ServerDeps): Hono {
+  const app = new Hono()
+
+  app.use('*', honoLogger((msg) => logger.debug(msg)))
+  app.use('/api/*', cors({ origin: '*' }))
+
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) return err.getResponse()
+    if (isMaestroError(err)) {
+      logger.error({ err }, 'request failed with MaestroError')
+      return c.json(
+        {
+          error: { code: err.code, message: err.message, context: err.context },
+        },
+        500,
+      )
+    }
+    logger.error({ err }, 'unhandled error')
+    return c.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      500,
+    )
+  })
+
+  app.get('/api/health', (c) => {
+    const body = HealthResponseSchema.parse({
+      status: 'ok',
+      version: deps.version,
+      uptimeSeconds: Math.round((Date.now() - deps.startedAt) / 1000),
+      timestamp: new Date().toISOString(),
+    })
+    return c.json(body)
+  })
+
+  app.get('/api/projects', (c) => {
+    const body = ListProjectsResponseSchema.parse({ projects: [] })
+    return c.json(body)
+  })
+
+  app.get('/api/sessions', (c) => {
+    const body = ListSessionsResponseSchema.parse({ sessions: [], total: 0 })
+    return c.json(body)
+  })
+
+  app.get('/api/prs', (c) => c.json({ pullRequests: [] }))
+
+  app.notFound((c) =>
+    c.json({ error: { code: 'NOT_FOUND', message: `No route for ${c.req.path}` } }, 404),
+  )
+
+  return app
+}

--- a/packages/conductor/src/state-manager.ts
+++ b/packages/conductor/src/state-manager.ts
@@ -1,0 +1,51 @@
+// .maestro/ file I/O. Reads state.md, context.md, journal entries, and parses
+// autonomy.json with Zod. Writes are locked per-project to prevent concurrent
+// session corruption. Phase 1 work (see PRODUCT_VISION.md).
+//
+// Stubs here so callers compile against the intended surface area.
+
+import type { ProjectAutonomyConfig, ProjectState, JournalEntry } from '@maestro/shared'
+import { MaestroError } from '@maestro/shared'
+
+export interface StateManagerInput {
+  /** Absolute path to the working checkout of the project. */
+  projectRoot: string
+}
+
+export async function readState(_input: StateManagerInput): Promise<ProjectState> {
+  throw notImplemented('readState')
+}
+
+export async function writeState(
+  _input: StateManagerInput & { state: ProjectState },
+): Promise<void> {
+  throw notImplemented('writeState')
+}
+
+export async function readContext(_input: StateManagerInput): Promise<string> {
+  throw notImplemented('readContext')
+}
+
+export async function readAutonomy(
+  _input: StateManagerInput,
+): Promise<ProjectAutonomyConfig> {
+  throw notImplemented('readAutonomy')
+}
+
+export async function listRecentJournal(
+  _input: StateManagerInput & { limit: number },
+): Promise<JournalEntry[]> {
+  throw notImplemented('listRecentJournal')
+}
+
+export async function appendJournal(
+  _input: StateManagerInput & { entry: JournalEntry },
+): Promise<void> {
+  throw notImplemented('appendJournal')
+}
+
+function notImplemented(name: string): MaestroError {
+  return new MaestroError('INTERNAL_ERROR', {
+    message: `state-manager.${name} is Phase 1 work. See PRODUCT_VISION.md.`,
+  })
+}

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -1,0 +1,23 @@
+// Session worker — spawns Claude Code, enforces the time budget, runs quality
+// gates, commits, and opens a PR. This is Phase 1 work (see PRODUCT_VISION.md
+// "Phase 1: Manual Single-Project Sessions"). The Phase 0 file is a stub so
+// the rest of the system can import it.
+
+import type Database from 'better-sqlite3'
+import type { Project } from '@maestro/shared'
+import { MaestroError } from '@maestro/shared'
+import type { Config } from './config.js'
+
+export interface RunSessionInput {
+  db: Database.Database
+  config: Config
+  project: Project
+  /** When true, build the prompt and log it without spawning Claude. */
+  dryRun?: boolean
+}
+
+export async function runSession(_input: RunSessionInput): Promise<never> {
+  throw new MaestroError('INTERNAL_ERROR', {
+    message: 'runSession is Phase 1 work. See PRODUCT_VISION.md.',
+  })
+}


### PR DESCRIPTION
## Summary
- Hono application with `/api/health`, `/api/projects`, `/api/sessions`, `/api/prs` (Phase 0 = read-only stubs)
- better-sqlite3 + idempotent migrations runner; initial migration creates all four operational tables
- Pino logger with structured context, pino-pretty in dev
- Zod-validated config loader; refuses to boot on invalid env
- Phase-deferred subsystems (scheduler, worker, state-manager, pr-manager, quality-gates, briefing) are stubs with file headers pointing at the phase that fills them in

## Test plan
- [x] `pnpm --filter @maestro/conductor build` succeeds
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Server boots, applies migrations, returns 200 from `/api/health`
- [x] `/api/projects` and `/api/sessions` return correct empty shapes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)