### PR TITLE
feat(dashboard): Vite + React + Tailwind UI with Maestro palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 # Build artifacts
 dist/
+dist-node/
 build/
 *.tsbuildinfo
 

--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <title>Maestro — Conductor for your codebases</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="bg-navy-900 text-navy-100 antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/dashboard/postcss.config.cjs
+++ b/packages/dashboard/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/packages/dashboard/public/favicon.svg
+++ b/packages/dashboard/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B1929"/>
+  <path d="M16 46V18l8 12 8-12 8 12 8-12v28" stroke="#F59E0B" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,0 +1,22 @@
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { Layout } from './components/Layout'
+import { Overview } from './pages/Overview'
+import { ProjectDetail } from './pages/ProjectDetail'
+import { Sessions } from './pages/Sessions'
+import { PRs } from './pages/PRs'
+import { Settings } from './pages/Settings'
+
+export function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<Overview />} />
+        <Route path="projects/:slug" element={<ProjectDetail />} />
+        <Route path="sessions" element={<Sessions />} />
+        <Route path="prs" element={<PRs />} />
+        <Route path="settings" element={<Settings />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Route>
+    </Routes>
+  )
+}

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,0 +1,122 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import { useEffect } from 'react'
+import { useStore } from '../store/useStore'
+import { useApi } from '../hooks/useApi'
+import type { HealthResponse } from '@maestro/api'
+
+interface NavItem {
+  to: string
+  label: string
+  exact?: boolean
+}
+
+const NAV: NavItem[] = [
+  { to: '/', label: 'Overview', exact: true },
+  { to: '/sessions', label: 'Sessions' },
+  { to: '/prs', label: 'Pull Requests' },
+  { to: '/settings', label: 'Settings' },
+]
+
+export function Layout() {
+  const { setHealth, health } = useStore()
+  const api = useApi()
+
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const res = await api.get<HealthResponse>('/api/health')
+        if (!cancelled) setHealth(res)
+      } catch {
+        if (!cancelled) setHealth(null)
+      }
+    }
+    void tick()
+    const id = window.setInterval(tick, 15_000)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [api, setHealth])
+
+  return (
+    <div className="flex h-full bg-navy-900 text-navy-100">
+      <aside className="hidden w-64 shrink-0 flex-col border-r border-navy-700/60 bg-navy-950/60 px-4 py-6 md:flex">
+        <BrandMark />
+        <nav className="mt-8 flex flex-col gap-1">
+          {NAV.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.exact}
+              className={({ isActive }) =>
+                `nav-link${isActive ? ' nav-link-active' : ''}`
+              }
+            >
+              <span>{item.label}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <div className="mt-auto pt-6 text-xs text-navy-300">
+          <p>Phase 0 — foundation</p>
+          <p className="mt-1 text-navy-400">v0.0.0</p>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex items-center justify-between border-b border-navy-700/60 bg-navy-900/80 px-6 py-4 backdrop-blur">
+          <div>
+            <h1 className="font-mono text-sm font-medium tracking-wide text-navy-200">
+              maestro
+            </h1>
+            <p className="text-xs text-navy-400">Conductor for your codebases</p>
+          </div>
+          <StatusIndicator health={health} />
+        </header>
+        <main className="flex-1 overflow-y-auto px-6 py-8">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+function BrandMark() {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="grid h-9 w-9 place-items-center rounded-lg border border-amber-700/40 bg-amber-900/20 text-amber-400">
+        <svg width="18" height="18" viewBox="0 0 64 64" aria-hidden>
+          <path
+            d="M16 46V18l8 12 8-12 8 12 8-12v28"
+            stroke="currentColor"
+            strokeWidth="5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <div>
+        <p className="font-semibold tracking-wide">Maestro</p>
+        <p className="text-xs text-navy-400">aaryansinha</p>
+      </div>
+    </div>
+  )
+}
+
+function StatusIndicator({ health }: { health: HealthResponse | null }) {
+  if (!health) {
+    return (
+      <span className="pill" aria-live="polite">
+        <span className="h-2 w-2 rounded-full bg-danger" />
+        conductor offline
+      </span>
+    )
+  }
+  return (
+    <span className="pill pill-success" aria-live="polite">
+      <span className="h-2 w-2 rounded-full bg-success-500" />
+      conductor up · {Math.floor(health.uptimeSeconds)}s
+    </span>
+  )
+}

--- a/packages/dashboard/src/hooks/useApi.ts
+++ b/packages/dashboard/src/hooks/useApi.ts
@@ -1,0 +1,41 @@
+// Thin fetch wrapper for the conductor API. The dev server proxies /api to
+// the conductor (see vite.config.ts), so a same-origin fetch works in dev and
+// in production when both are served from one Hono app.
+
+import { useMemo } from 'react'
+
+interface ApiClient {
+  get<T>(path: string, init?: RequestInit): Promise<T>
+  post<T>(path: string, body?: unknown, init?: RequestInit): Promise<T>
+}
+
+export function useApi(): ApiClient {
+  return useMemo(() => {
+    const base = import.meta.env.VITE_API_BASE_URL ?? ''
+
+    async function request<T>(path: string, init: RequestInit): Promise<T> {
+      const res = await fetch(`${base}${path}`, {
+        ...init,
+        headers: {
+          'content-type': 'application/json',
+          ...(init.headers ?? {}),
+        },
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`API ${res.status} ${res.statusText}: ${text}`)
+      }
+      return (await res.json()) as T
+    }
+
+    return {
+      get: (path, init) => request(path, { method: 'GET', ...(init ?? {}) }),
+      post: (path, body, init) =>
+        request(path, {
+          method: 'POST',
+          body: body ? JSON.stringify(body) : undefined,
+          ...(init ?? {}),
+        }),
+    }
+  }, [])
+}

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -1,0 +1,73 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    font-feature-settings:
+      'cv11',
+      'ss01',
+      'ss02';
+  }
+
+  code,
+  pre,
+  kbd {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+  }
+}
+
+@layer components {
+  .panel {
+    @apply rounded-xl border border-navy-700/70 bg-navy-800/50 backdrop-blur-sm;
+  }
+
+  .panel-header {
+    @apply flex items-center justify-between border-b border-navy-700/70 px-5 py-3;
+  }
+
+  .nav-link {
+    @apply flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-navy-200 transition hover:bg-navy-700/50 hover:text-white;
+  }
+
+  .nav-link-active {
+    @apply bg-navy-700 text-white;
+  }
+
+  .pill {
+    @apply inline-flex items-center gap-1.5 rounded-full border border-navy-600 bg-navy-800 px-2.5 py-0.5 text-xs font-medium text-navy-200;
+  }
+
+  .pill-amber {
+    @apply border-amber-700/60 bg-amber-900/30 text-amber-300;
+  }
+
+  .pill-success {
+    @apply border-success-700/60 bg-success-700/20 text-success-400;
+  }
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(20, 43, 71, 0.7);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(36, 70, 112, 0.9);
+}

--- a/packages/dashboard/src/main.tsx
+++ b/packages/dashboard/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { App } from './App'
+import './index.css'
+
+const rootEl = document.getElementById('root')
+if (!rootEl) throw new Error('Missing #root element')
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+)

--- a/packages/dashboard/src/pages/Overview.tsx
+++ b/packages/dashboard/src/pages/Overview.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react'
+import { useApi } from '../hooks/useApi'
+import type { ListProjectsResponse } from '@maestro/api'
+
+export function Overview() {
+  const api = useApi()
+  const [data, setData] = useState<ListProjectsResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void api
+      .get<ListProjectsResponse>('/api/projects')
+      .then((res) => {
+        if (!cancelled) setData(res)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Unknown error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api])
+
+  return (
+    <section className="mx-auto max-w-6xl">
+      <header className="mb-8">
+        <p className="text-xs uppercase tracking-[0.2em] text-amber-500">Projects</p>
+        <h2 className="mt-1 text-2xl font-semibold text-white">Overview</h2>
+        <p className="mt-1 text-sm text-navy-300">
+          All projects under Maestro management. Each card surfaces current state, recent
+          activity, and pending review.
+        </p>
+      </header>
+
+      {error ? <ErrorCard message={error} /> : null}
+
+      {!data ? (
+        <SkeletonGrid />
+      ) : data.projects.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {data.projects.map((p) => (
+            <article key={p.id} className="panel p-5">
+              <h3 className="font-mono text-sm text-navy-200">{p.slug}</h3>
+              <p className="mt-2 text-xs text-navy-400">{p.repoUrl}</p>
+              <span className="pill pill-amber mt-4">{p.autonomyConfig.level}</span>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="panel flex flex-col items-center justify-center px-8 py-16 text-center">
+      <div className="mb-5 grid h-14 w-14 place-items-center rounded-2xl border border-amber-700/40 bg-amber-900/20 text-amber-400">
+        <svg width="24" height="24" viewBox="0 0 64 64" aria-hidden>
+          <path
+            d="M16 46V18l8 12 8-12 8 12 8-12v28"
+            stroke="currentColor"
+            strokeWidth="5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+          />
+        </svg>
+      </div>
+      <h3 className="text-lg font-semibold text-white">No projects yet</h3>
+      <p className="mt-2 max-w-md text-sm text-navy-300">
+        Add a repository to put it under autonomous management. The first session is for
+        orientation — no code changes, just observation.
+      </p>
+      <pre className="mt-6 inline-block rounded-lg border border-navy-700 bg-navy-950/70 px-4 py-2 text-xs text-amber-200">
+        maestro add &lt;repo-url&gt;
+      </pre>
+    </div>
+  )
+}
+
+function SkeletonGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="panel h-40 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+function ErrorCard({ message }: { message: string }) {
+  return (
+    <div className="panel mb-6 border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+      Conductor unreachable: <span className="font-mono">{message}</span>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/PRs.tsx
+++ b/packages/dashboard/src/pages/PRs.tsx
@@ -1,0 +1,12 @@
+import { Placeholder } from './_Placeholder'
+
+export function PRs() {
+  return (
+    <Placeholder
+      eyebrow="Review queue"
+      title="Pull Requests"
+      body="One-click review of every PR Maestro opened on your behalf. Lands in Phase 3 with the dashboard."
+      reference="PRODUCT_VISION.md → Phase 3"
+    />
+  )
+}

--- a/packages/dashboard/src/pages/ProjectDetail.tsx
+++ b/packages/dashboard/src/pages/ProjectDetail.tsx
@@ -1,0 +1,14 @@
+import { useParams } from 'react-router-dom'
+import { Placeholder } from './_Placeholder'
+
+export function ProjectDetail() {
+  const { slug } = useParams<{ slug: string }>()
+  return (
+    <Placeholder
+      eyebrow="Projects"
+      title={slug ? `Project: ${slug}` : 'Project'}
+      body="Per-project view: state, journal, sessions, autonomy. Lands in Phase 3."
+      reference="PRODUCT_VISION.md → Phase 3"
+    />
+  )
+}

--- a/packages/dashboard/src/pages/Sessions.tsx
+++ b/packages/dashboard/src/pages/Sessions.tsx
@@ -1,0 +1,12 @@
+import { Placeholder } from './_Placeholder'
+
+export function Sessions() {
+  return (
+    <Placeholder
+      eyebrow="Activity"
+      title="Sessions"
+      body="Session history across every managed project. Each session lists what the agent did, why, and what worked. Lands in Phase 3."
+      reference="PRODUCT_VISION.md → Phase 3"
+    />
+  )
+}

--- a/packages/dashboard/src/pages/Settings.tsx
+++ b/packages/dashboard/src/pages/Settings.tsx
@@ -1,0 +1,12 @@
+import { Placeholder } from './_Placeholder'
+
+export function Settings() {
+  return (
+    <Placeholder
+      eyebrow="Configuration"
+      title="Settings"
+      body="Per-project autonomy levels, schedules, quality gates, and global cost guardrails. Lands in Phase 3."
+      reference="PRODUCT_VISION.md → Phase 3"
+    />
+  )
+}

--- a/packages/dashboard/src/pages/_Placeholder.tsx
+++ b/packages/dashboard/src/pages/_Placeholder.tsx
@@ -1,0 +1,24 @@
+// Shared placeholder layout for pages that land in later phases. Lets the
+// dashboard look polished even before its real content is wired up.
+
+interface Props {
+  eyebrow: string
+  title: string
+  body: string
+  reference: string
+}
+
+export function Placeholder({ eyebrow, title, body, reference }: Props) {
+  return (
+    <section className="mx-auto max-w-3xl">
+      <header className="mb-8">
+        <p className="text-xs uppercase tracking-[0.2em] text-amber-500">{eyebrow}</p>
+        <h2 className="mt-1 text-2xl font-semibold text-white">{title}</h2>
+      </header>
+      <div className="panel px-6 py-10 text-center">
+        <p className="mx-auto max-w-md text-sm text-navy-300">{body}</p>
+        <p className="mt-4 font-mono text-xs text-navy-400">{reference}</p>
+      </div>
+    </section>
+  )
+}

--- a/packages/dashboard/src/store/useStore.ts
+++ b/packages/dashboard/src/store/useStore.ts
@@ -1,0 +1,15 @@
+// Zustand store. Phase 0 holds only conductor health; Phase 3 adds projects,
+// sessions, PR queue. See PRODUCT_VISION.md "Phase 3: The Dashboard".
+
+import { create } from 'zustand'
+import type { HealthResponse } from '@maestro/api'
+
+interface State {
+  health: HealthResponse | null
+  setHealth: (h: HealthResponse | null) => void
+}
+
+export const useStore = create<State>((set) => ({
+  health: null,
+  setHealth: (health) => set({ health }),
+}))

--- a/packages/dashboard/src/vite-env.d.ts
+++ b/packages/dashboard/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/packages/dashboard/tailwind.config.ts
+++ b/packages/dashboard/tailwind.config.ts
@@ -1,0 +1,60 @@
+import type { Config } from 'tailwindcss'
+
+// Maestro palette per PRODUCT_VISION.md "Brand and Identity":
+//   Deep navy base (#0B1929), warm amber accent (#F59E0B), muted greens for
+//   success states. Inter for UI, JetBrains Mono for code.
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        // Deep navy base, surfaces a few shades up.
+        navy: {
+          950: '#070F1B',
+          900: '#0B1929',
+          800: '#0F2238',
+          700: '#142B47',
+          600: '#1B375A',
+          500: '#244670',
+          400: '#3A6391',
+          300: '#5783B3',
+          200: '#85A8CD',
+          100: '#BCD3E5',
+        },
+        // Warm amber accent.
+        amber: {
+          DEFAULT: '#F59E0B',
+          50: '#FEF6E1',
+          100: '#FCE6B0',
+          200: '#FAD27A',
+          300: '#F8BE45',
+          400: '#F6AD20',
+          500: '#F59E0B',
+          600: '#C77F08',
+          700: '#985F06',
+          800: '#6B4204',
+          900: '#3F2602',
+        },
+        // Muted success greens.
+        success: {
+          400: '#86C8A4',
+          500: '#5BAE82',
+          600: '#3F8B62',
+          700: '#2C6648',
+        },
+        warning: '#E8A33A',
+        danger: '#D8584F',
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
+      },
+      boxShadow: {
+        glow: '0 0 0 1px rgba(245, 158, 11, 0.20), 0 8px 32px -12px rgba(245, 158, 11, 0.30)',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+})


### PR DESCRIPTION
## Summary
- Vite 6 + React 18 + TypeScript strict, Tailwind 3 with the Maestro palette (deep navy, amber, muted greens)
- Inter for UI, JetBrains Mono for code
- React Router 6 with Layout-wrapped routes: Overview / ProjectDetail / Sessions / PRs / Settings
- Zustand store skeleton + `useApi` hook with `/api` proxy through Vite
- Sidebar layout with conductor health indicator that pings `/api/health` every 15s
- Overview page surfaces a polished empty-state pointing at `maestro add <repo-url>`; the rest of the pages use a shared `Placeholder` component referencing the phase that fills them in

## Notable choices
- Dark mode by default — `class="dark"` on `<html>`, `color-scheme: dark` meta
- Build is `tsc -b && vite build` so type errors block the bundle
- Dashboard's static build will be served from the conductor in Phase 3; for now it stands alone with the Vite dev proxy

## Test plan
- [x] `pnpm --filter @maestro/dashboard build` succeeds (~175 KB JS, 11.7 KB CSS)
- [x] `pnpm typecheck` and `pnpm lint` pass
- [x] Dev server boots, proxy forwards `/api/*` to the conductor
- [x] Status indicator shows "conductor up · Ns" when the conductor is running and "conductor offline" otherwise

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)