### PR TITLE
feat(cli, ops): maestro CLI, Dockerfile, Railway config, deploy docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+**/node_modules
+**/dist
+**/.turbo
+**/.vite
+data/
+work/
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+*.log
+coverage/
+.vscode/
+.idea/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# Multi-stage Dockerfile for the Maestro conductor.
+#
+# Stage 1: install all workspace deps and build every package (typescript +
+# vite). Stage 2: copy the built artifacts and only the production deps the
+# conductor needs at runtime. The image runs the conductor + serves the static
+# dashboard from the Hono app's working tree.
+#
+# git is installed because future phases run `simple-git` against managed
+# project repos. The Claude Code CLI is intentionally NOT baked into this
+# image — it must be installed and OAuth'd interactively on the host, per
+# ADR-001.
+
+# ─── builder ─────────────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS builder
+
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH \
+    CI=true
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 build-essential ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@10.8.1 --activate
+
+WORKDIR /app
+
+# Copy lockfile and manifests first for better layer caching.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml* ./
+COPY tsconfig.json tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/
+COPY packages/api/package.json packages/api/
+COPY packages/conductor/package.json packages/conductor/
+COPY packages/dashboard/package.json packages/dashboard/
+
+RUN pnpm install --frozen-lockfile=false
+
+# Now copy the rest of the source and build.
+COPY . .
+RUN pnpm build
+
+# Prune to production deps for the conductor only. --legacy keeps the v9
+# behaviour of producing a self-contained, non-injected deploy directory.
+RUN pnpm --filter @maestro/conductor deploy --legacy --prod /prod/conductor
+
+# ─── runtime ─────────────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS runtime
+
+ENV NODE_ENV=production \
+    MAESTRO_PORT=3000 \
+    MAESTRO_DATA_DIR=/data
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates git tini \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system --gid 1001 maestro \
+  && useradd  --system --uid 1001 --gid maestro --create-home maestro
+
+WORKDIR /app
+
+# Conductor runtime artefact (production deps + compiled JS + migrations).
+COPY --from=builder --chown=maestro:maestro /prod/conductor /app/conductor
+
+# Dashboard static build, served from inside the conductor process tree.
+COPY --from=builder --chown=maestro:maestro /app/packages/dashboard/dist /app/dashboard
+
+RUN mkdir -p /data && chown maestro:maestro /data
+USER maestro
+
+EXPOSE 3000
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "/app/conductor/dist/index.js"]

--- a/bin/maestro.mjs
+++ b/bin/maestro.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Bin shim for the `maestro` CLI. Resolves tsx from the local node_modules and
+// hands off to scripts/cli.ts so users get a full TypeScript experience without
+// a build step. When the package is published, this can be replaced with the
+// compiled ./dist/cli.js entry.
+
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { existsSync } from 'node:fs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const root = resolve(here, '..')
+const cliPath = resolve(root, 'scripts', 'cli.ts')
+
+const candidates = [
+  resolve(root, 'node_modules', '.bin', 'tsx'),
+  resolve(root, 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+]
+const tsxBin = candidates.find((p) => existsSync(p))
+
+if (!tsxBin) {
+  console.error('maestro: tsx binary not found. Run `pnpm install` first.')
+  process.exit(1)
+}
+
+const child = spawn(process.execPath, [tsxBin, cliPath, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: process.env,
+})
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal)
+  else process.exit(code ?? 0)
+})

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,71 @@
+# Deployment
+
+Maestro is designed to run as a single long-lived service on a small VPS. The
+canonical target is [Railway](https://railway.app) — one Dockerfile, one
+volume, one set of environment variables.
+
+## Prerequisites
+
+- A Railway project with a paid plan (the conductor needs to stay up).
+- A volume (recommend 5GB) mounted at `/data` for the SQLite database and
+  per-project working clones.
+- A fine-grained GitHub PAT with read/write on the repos Maestro will manage.
+- A Telegram bot token (Phase 4+) and the chat id from `@userinfobot`.
+- The Anthropic API key is optional — Maestro spawns the local `claude` CLI
+  authenticated to your Pro/Max subscription (see ADR-001 in `DECISIONS.md`).
+
+## First-time setup on Railway
+
+1. **Create a new project** in Railway and point it at this repository.
+2. Railway detects the `Dockerfile` automatically. Build and deploy once to
+   verify the image builds and the conductor reaches `/api/health`.
+3. **Add a volume** with mount path `/data`.
+4. **Set environment variables** (copy from `.env.example`):
+   - `GITHUB_TOKEN`
+   - `TELEGRAM_BOT_TOKEN` (optional in Phase 0)
+   - `TELEGRAM_CHAT_ID` (optional in Phase 0)
+   - `DEVELOPER_NAME=Aaryan Sinha`
+   - `DEVELOPER_EMAIL=<your GitHub email>`
+   - `DEVELOPER_GITHUB_USERNAME=aaryansinha16`
+   - `MAESTRO_DATA_DIR=/data`
+   - `MAESTRO_PORT=3000`
+5. **Public domain**: enable a domain for the service (Railway → Settings →
+   Public Networking). The Hono server listens on `MAESTRO_PORT`.
+6. **Verify**: hit `https://<your-domain>/api/health` and confirm a 200.
+
+## Authenticating the Claude Code CLI
+
+ADR-001 commits Maestro to using the local `claude` CLI rather than the
+Anthropic API. Railway's Docker image deliberately does **not** install
+Claude Code — the OAuth flow needs an interactive shell. Two options:
+
+- **Production**: SSH (or use Railway's "Deploy → Shell") into the running
+  container with the volume mounted, install Claude Code, run `claude
+  /login`, and finish the OAuth flow. Repeat after token expiry.
+- **Self-hosted on a VPS** (recommended for the developer's own use): run
+  `pnpm install && pnpm build` on the VPS directly, install Claude Code,
+  authenticate once, then run the conductor under a process supervisor
+  (systemd, pm2, etc.). The Dockerfile is for parity testing and future
+  multi-tenant deploys.
+
+## Verifying a deploy
+
+```bash
+curl https://maestro.<your-domain>/api/health
+# → { "status": "ok", "version": "0.0.0", "uptimeSeconds": 8, ... }
+```
+
+The dashboard is served as a static build alongside the conductor in
+production. In Phase 0 the static assets are built but not yet wired into
+the Hono app (Phase 3 mounts them); for now, run the dashboard locally
+against the deployed conductor by exporting `VITE_API_BASE_URL`.
+
+## Updating
+
+```bash
+git push origin main
+# Railway redeploys automatically.
+```
+
+Volume contents (the SQLite DB and any working clones under `/data`) are
+preserved across deploys.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -1,0 +1,103 @@
+# Project Onboarding
+
+How to bring a project under Maestro management. The onboarding flow is
+deliberately friction-heavy — better to spend an hour setting a project up
+well than to have weeks of bad agent commits (per `PROJECT_CONFIG.md`).
+
+> Phase 0 status: this document describes the intended end-state. The CLI
+> commands referenced here (`maestro init`, `maestro add`, `maestro run`) are
+> stubs in Phase 0 and become real in Phases 1-2.
+
+## 1. Create the `.maestro/` directory
+
+In the project's working tree:
+
+```text
+.maestro/
+├── state.md
+├── context.md
+├── decisions.md
+├── autonomy.json
+└── journal/
+```
+
+The full contract for these files is in `CLAUDE.md` (root of this repo)
+under "The .maestro/ Directory Contract".
+
+## 2. Write `context.md` (long-lived)
+
+Architecture overview, conventions, key files, gotchas. The agent reads this
+every session. Keep it ~200-500 lines. Include:
+
+- Tech stack and main entry points
+- Code style and naming conventions
+- Commit message format
+- Test commands and patterns
+- Project-specific NEVER-touch list
+- Any external systems the project integrates with
+
+## 3. Write `state.md` (immediate work)
+
+Current focus, 3-5 concrete next tasks, blockers. The agent picks one task
+per session from "Next Concrete Tasks". See `CLAUDE.md` for the section
+template.
+
+## 4. Configure `autonomy.json`
+
+```json
+{
+  "level": "pr-only",
+  "schedule": "0 */6 * * *",
+  "timeBudget": 2700,
+  "qualityGates": ["test", "lint", "typecheck"],
+  "branches": { "base": "main", "prefix": "maestro/" },
+  "github": { "prLabels": ["maestro"], "draftByDefault": false },
+  "skipDays": [],
+  "maxSessionsPerDay": 6
+}
+```
+
+`timeBudget` is in seconds. Default 2700 (45 minutes). See
+`PROJECT_CONFIG.md` for the developer's per-project decisions.
+
+## 5. Commit `.maestro/` to the project repo
+
+The directory travels with the code (ADR-004). Both your active sessions and
+Maestro's autonomous sessions read the same files.
+
+## 6. Register with Maestro
+
+```bash
+maestro add <repo-url>
+```
+
+## 7. Dry-run the first session
+
+```bash
+maestro run <project> --dry-run
+```
+
+This prints the constructed prompt without spawning Claude. Read it. If
+anything looks off, the fix is almost always in `state.md` or `context.md`,
+not in the agent.
+
+## 8. Real first session
+
+```bash
+maestro run <project>
+```
+
+For a brand-new project the first session is intentionally orientation-only
+(see the FIRST SESSION preamble in `packages/shared/src/prompt-templates.ts`).
+The next session will start real work.
+
+## 9. Review the resulting PR carefully
+
+The first 2 weeks of any project are for building trust with the system.
+Review every PR. When something is wrong, update `state.md` or `context.md`
+rather than trying to "fix" the agent.
+
+## 10. Enable the schedule
+
+Once you've shipped a few good PRs from manual sessions, switch the project
+on. The schedule in `autonomy.json` takes effect on the next scheduler tick.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "node /app/conductor/dist/index.js",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 30
+  }
+}

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env tsx
+// `maestro` CLI. Lightweight wrapper around the conductor API for tasks the
+// developer runs from the terminal.
+//
+// Phase 0: `list` and `status` hit the API. `add` and `run` are stubbed to
+// "not implemented" — the actual project registration and session triggering
+// arrive in Phases 1 and 2 respectively.
+
+import { cac } from 'cac'
+import type { HealthResponse, ListProjectsResponse } from '@maestro/api'
+
+const PACKAGE_VERSION = '0.0.0'
+const DEFAULT_API_BASE = process.env.MAESTRO_API_BASE ?? 'http://localhost:3000'
+
+const cli = cac('maestro')
+
+cli
+  .command('add <repo-url>', 'Register a GitHub repository with Maestro')
+  .option('--autonomy <level>', 'Autonomy level (full|pr-only|draft-only|paused)', {
+    default: 'pr-only',
+  })
+  .option('--schedule <cron>', 'Cron schedule', { default: '0 */6 * * *' })
+  .action((_repoUrl: string, _opts: unknown) => {
+    notImplemented(
+      'maestro add',
+      'Project registration arrives in Phase 1. See PRODUCT_VISION.md.',
+    )
+  })
+
+cli
+  .command('run <project>', 'Manually trigger a session for a project')
+  .option('--dry-run', 'Build the prompt and log it without spawning Claude')
+  .action((_project: string, _opts: { dryRun?: boolean }) => {
+    notImplemented(
+      'maestro run',
+      'Manual session execution arrives in Phase 1. See PRODUCT_VISION.md.',
+    )
+  })
+
+cli
+  .command('list', 'List projects under Maestro management')
+  .option('--api <url>', 'Override the conductor API base URL', {
+    default: DEFAULT_API_BASE,
+  })
+  .action(async (opts: { api: string }) => {
+    const data = await fetchJson<ListProjectsResponse>(opts.api, '/api/projects')
+    if (data.projects.length === 0) {
+      console.log('No projects yet. Add one with: maestro add <repo-url>')
+      return
+    }
+    for (const p of data.projects) {
+      console.log(`${p.slug.padEnd(24)}  ${p.autonomyConfig.level.padEnd(12)}  ${p.repoUrl}`)
+    }
+  })
+
+cli
+  .command('status', 'Conductor health check')
+  .option('--api <url>', 'Override the conductor API base URL', {
+    default: DEFAULT_API_BASE,
+  })
+  .action(async (opts: { api: string }) => {
+    const health = await fetchJson<HealthResponse>(opts.api, '/api/health')
+    console.log(`status     ${health.status}`)
+    console.log(`version    ${health.version}`)
+    console.log(`uptime     ${health.uptimeSeconds}s`)
+    console.log(`timestamp  ${health.timestamp}`)
+  })
+
+cli.help()
+cli.version(PACKAGE_VERSION)
+
+try {
+  cli.parse(process.argv, { run: false })
+  await cli.runMatchedCommand()
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err)
+  process.exit(1)
+}
+
+function notImplemented(name: string, why: string): never {
+  console.error(`${name}: not implemented`)
+  console.error(why)
+  process.exit(2)
+}
+
+async function fetchJson<T>(base: string, path: string): Promise<T> {
+  const url = `${base.replace(/\/$/, '')}${path}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} (${url})`)
+  }
+  return (await res.json()) as T
+}


### PR DESCRIPTION
## Summary
- `maestro` CLI built with `cac`. Subcommands: `add` and `run` (Phase 1 stubs), `list` and `status` (live, hit the conductor)
- Bin shim at `bin/maestro.mjs` so the CLI runs from a packaged bin entry without a build step
- Multi-stage Dockerfile: builder installs the full workspace; runtime image is non-root, runs only the production conductor + the static dashboard build, uses tini as PID 1, persists SQLite to a `/data` volume
- `railway.json` configures Dockerfile builder, /api/health healthcheck, restart-on-failure
- `docs/DEPLOYMENT.md` walks through Railway setup including the Claude Code OAuth caveat (ADR-001)
- `docs/PROJECT_ONBOARDING.md` describes the .maestro/ contract end-to-end
- `README.md` gets the full Maestro pitch

## Test plan
- [x] `pnpm cli status` reports the running conductor's health
- [x] `pnpm cli list` returns the empty-projects state
- [x] `pnpm cli --help` lists all four commands
- [x] `docker build -t maestro:phase0 .` builds end to end
- [x] `docker run` boots the image, applies migrations, serves /api/health 200 from the non-root user

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)