### PR TITLE
fix(cli): bin shim crashes Node when invoked via npx

### DIFF
--- a/bin/maestro.mjs
+++ b/bin/maestro.mjs
@@ -1,34 +1,34 @@
 #!/usr/bin/env node
-// Bin shim for the `maestro` CLI. Resolves tsx from the local node_modules and
-// hands off to scripts/cli.ts so users get a full TypeScript experience without
-// a build step. When the package is published, this can be replaced with the
-// compiled ./dist/cli.js entry.
+// Bin shim for the `maestro` CLI. Loads scripts/cli.ts in this same Node
+// process via tsx's ESM API — no child process, no shell script invocation.
+// When the package is published, this can be replaced with the compiled
+// ./dist/cli.js entry.
 
-import { spawn } from 'node:child_process'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
 const cliPath = resolve(root, 'scripts', 'cli.ts')
 
-const candidates = [
-  resolve(root, 'node_modules', '.bin', 'tsx'),
-  resolve(root, 'node_modules', 'tsx', 'dist', 'cli.mjs'),
-]
-const tsxBin = candidates.find((p) => existsSync(p))
-
-if (!tsxBin) {
-  console.error('maestro: tsx binary not found. Run `pnpm install` first.')
+if (!existsSync(cliPath)) {
+  console.error(`maestro: scripts/cli.ts not found at ${cliPath}`)
   process.exit(1)
 }
 
-const child = spawn(process.execPath, [tsxBin, cliPath, ...process.argv.slice(2)], {
-  stdio: 'inherit',
-  env: process.env,
-})
-child.on('exit', (code, signal) => {
-  if (signal) process.kill(process.pid, signal)
-  else process.exit(code ?? 0)
-})
+let tsImport
+try {
+  ;({ tsImport } = await import('tsx/esm/api'))
+} catch (err) {
+  console.error('maestro: tsx is not installed. Run `pnpm install` first.')
+  console.error(err instanceof Error ? err.message : err)
+  process.exit(1)
+}
+
+try {
+  await tsImport(pathToFileURL(cliPath).href, import.meta.url)
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
Reported during smoke testing immediately after Phase 0 landed. `npx maestro <cmd>` crashed Node with a SyntaxError parsing the tsx shell script as JavaScript.

## Root cause
`bin/maestro.mjs` invoked:

```js
spawn(process.execPath, [tsxBin, cliPath, ...args])
```

`process.execPath` is `node`; `tsxBin` resolves to `node_modules/.bin/tsx`, which is a POSIX shell script (`#!/bin/sh ...`). Telling Node to execute a shell script as JavaScript blows up on the first shell expression (`basedir=$(...)`).

## Fix
Use tsx's ESM API — `tsImport()` — to load `scripts/cli.ts` in the same Node process. No child process, no shell-script invocation, faster startup.

## Test plan
- [x] `npx maestro --version` → `maestro/0.0.0 darwin-arm64 node-vNN`
- [x] `npx maestro --help` → lists all subcommands
- [x] `npx maestro add <url>` → "not implemented" (Phase 1)
- [x] `npx maestro status` → hits the running conductor and prints uptime
- [x] `pnpm lint` clean

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)