### PR TITLE
feat(conductor): Phase 1 — single-project session execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ build/
 # Working directories (per-project clones for autonomous sessions)
 work/
 /data/
+# A scratch sandbox the developer may sit beside the repo for smoke tests.
+/maestro-test/
 
 # Logs
 logs/

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,8 +2,6 @@
 
 Record every non-trivial technical decision here. Format: number, date, decision, reasoning, alternatives considered.
 
----
-
 ## ADR-001: Use Claude Code CLI Subscription, Not API
 
 **Date**: 2026-04-28  
@@ -21,8 +19,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - Subscription rate limits apply
 - Will need to monitor usage and back off if hitting limits
 
----
-
 ## ADR-002: Hono over Express
 
 **Date**: 2026-04-28  
@@ -35,8 +31,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - (b) Fastify — fast but more complex
 - (c) Bare Node http — too low-level
 
----
-
 ## ADR-003: SQLite for Persistence
 
 **Date**: 2026-04-28  
@@ -48,8 +42,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - (a) Postgres — overkill, adds deployment complexity
 - (b) JSON files — fine but no querying
 - (c) DuckDB — interesting for analytics but unnecessary
-
----
 
 ## ADR-004: .maestro/ Directory Lives in Each Project
 
@@ -73,8 +65,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - Structure must be stable; format changes require migrations
 - The agent reads and writes these files within its working directory each session
 
----
-
 ## ADR-005: PR-Only Default Autonomy
 
 **Date**: 2026-04-28  
@@ -86,8 +76,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - (a) `full` default — risky, contrary to system goals
 - (b) Always `draft-only` — too friction-heavy for trusted projects
 
----
-
 ## ADR-006: Quality Gates Are Pre-PR, Not Pre-Commit
 
 **Date**: 2026-04-28  
@@ -98,8 +86,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 **Alternatives**:
 - (a) Pre-commit gates that abort the work — loses partial progress
 - (b) No gates at all — produces low-quality PRs
-
----
 
 ## ADR-007: Time Budget Enforced via Process Kill
 
@@ -115,8 +101,6 @@ Record every non-trivial technical decision here. Format: number, date, decision
 
 **Implications**: The agent is told its budget upfront and is instructed to "wrap up cleanly with 5 minutes left." Most sessions self-terminate before kill.
 
----
-
 ## ADR-008: Sequential Sessions Per Project, Parallel Across Projects
 
 **Date**: 2026-04-28  
@@ -128,16 +112,12 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - (a) Always sequential — wastes idle time
 - (b) Always parallel — same-project conflicts
 
----
-
 ## ADR-009: GitHub-Only for v1
 
 **Date**: 2026-04-28  
 **Decision**: v1 supports only GitHub repositories. GitLab, Bitbucket, self-hosted Git deferred.
 
 **Reasoning**: The developer uses GitHub. Octokit is mature. GitLab support is a future expansion, not v1 work.
-
----
 
 ## ADR-010: Telegram for Briefings, Web for Detail
 
@@ -150,6 +130,76 @@ Record every non-trivial technical decision here. Format: number, date, decision
 - (a) Email briefings — pushy, less interactive
 - (b) Slack — only relevant if developer uses Slack
 - (c) Mobile app — overkill for v1
+
+## ADR-011: Claude Code CLI invocation for autonomous sessions
+
+**Date**: 2026-04-28
+**Decision**: Spawn `claude -p "<prompt-via-stdin>"` with these flags for every Maestro session:
+
+```
+claude -p
+  --permission-mode bypassPermissions
+  --allowedTools "Read Edit Write Bash Glob Grep"
+  --no-session-persistence
+  --output-format stream-json
+  --include-partial-messages
+  --verbose
+  --add-dir <working-dir>
+```
+
+The prompt itself is fed via stdin (not as a positional arg) to keep clear of `ARG_MAX` limits with long contexts.
+
+**Reasoning**:
+- `-p` is the documented non-interactive mode flag.
+- `bypassPermissions` is the only mode that allows full file editing + bash without prompting. The agent's working directory is sandboxed under `MAESTRO_DATA_DIR/work/<slug>`, so the trust boundary is the directory, not the permission dialogue.
+- `--allowedTools` is advisory under `bypassPermissions` but documents intent and limits damage if the mode flag changes.
+- `--no-session-persistence` keeps each Maestro session isolated from the developer's interactive Claude history.
+- `stream-json` + `--include-partial-messages` + `--verbose` gives one JSON object per line, with the final `result` object carrying `usage` for cost tracking.
+
+**Things we deliberately AVOID**:
+- `--bare` — bypasses the keychain and forces `ANTHROPIC_API_KEY`. Contradicts ADR-001 (Pro/Max OAuth subscription).
+- `--continue`, `--resume` — load from the global session store; breaks isolation between projects.
+- `--dangerously-skip-permissions` — alias for the `bypassPermissions` mode but suggests carelessness; we use the explicit mode flag.
+- `--max-turns` — claimed by the documentation guide but doesn't actually appear in `claude --help` output as of v2.1.118; we don't pass it.
+
+**Implications**:
+- The conductor must run on a host where `claude` is on PATH and an interactive `claude /login` has been completed at least once.
+- Cost is parsed from the final `result` line's `usage` object using the published rate card (input $3/M, output $15/M, cache write $3.75/M, cache read $0.30/M). Stored as integer cents on the session row.
+
+## ADR-012: Per-project lock via SQLite row-with-pid
+
+**Date**: 2026-04-28
+**Decision**: Per-project advisory locks live in a SQLite `project_locks` table with `project_id` as the primary key. Lock acquisition is `INSERT OR ABORT` (atomic via the unique constraint) and the row records the holder's pid + session id.
+
+On startup, the conductor releases any locks whose pid matches the current process — so a crashed conductor reclaims its own locks rather than leaving them stuck. On acquire, if a lock exists but the holder pid is dead (signal-0 probe), we steal it.
+
+**Reasoning**: SQLite has no native session locks. The alternative — a filesystem flock — works on a single machine but doesn't expose the holder identity to the dashboard, makes inspection harder, and would require a separate lockfile path scheme. Embedding the lock in the same SQLite file the rest of the operational state lives in keeps everything atomic and queryable.
+
+**Implications**:
+- The conductor is single-tenant per host. Running two conductors against the same SQLite file would still serialise correctly (SQLite's PRIMARY KEY is atomic), but the pid-staleness check assumes you're checking pids on the same host. That's fine for v1.
+- ADR-008 (sequential per-project) is now enforced at the data layer, not just the application layer.
+
+## ADR-013: Quality-gate-failed → exactly one fixup turn
+
+**Date**: 2026-04-28
+**Decision**: When quality gates fail after the agent's commit, Maestro spawns exactly one fixup turn with a 15-minute budget (`FIXUP_TURN_BUDGET_SECONDS`). If gates still fail after the fixup, the branch is pushed and labelled `quality-gates-failed` (when the GitHub client is configured) but no PR opens.
+
+**Reasoning**: Repeated fixup turns turn into thrashing; the 15-minute budget is what PROMPT_DESIGN.md specified. One retry catches the common case (a missing import, a typo, a small logic error the test surfaced) while bounding cost.
+
+**Alternatives**:
+- (a) No fixup turn — wastes the agent's earlier work when a one-line fix would unblock it.
+- (b) Multiple fixup turns — diminishing returns; if the first fixup didn't work the issue likely needs human review.
+
+**Implications**: Each fixup turn is recorded as a separate session row with `is_fixup_turn = 1` and `parent_session_id` set. The dashboard shows the fixup as a child session.
+
+## ADR-014: Whitelist environment for the agent process
+
+**Date**: 2026-04-28
+**Decision**: When spawning `claude` (and quality-gate processes), pass through only `PATH`, `HOME`, `LANG`, `LC_ALL`, `TERM`, `SHELL`, `TMPDIR`, and `CI`. The full conductor process environment is **not** forwarded.
+
+**Reasoning**: The conductor's environment contains `GITHUB_TOKEN`, `TELEGRAM_BOT_TOKEN`, future API keys, and developer dotfiles that would otherwise leak into agent shell sessions. The whitelist gives the agent enough to run tests and build tools without exposing operational secrets.
+
+**Implications**: If a managed project's tests genuinely need an environment variable, the agent has to ask via state.md and the developer adds it explicitly to the conductor's allowlist. We accept that friction in exchange for the security boundary.
 
 ---
 

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -4,100 +4,146 @@ How to bring a project under Maestro management. The onboarding flow is
 deliberately friction-heavy — better to spend an hour setting a project up
 well than to have weeks of bad agent commits (per `PROJECT_CONFIG.md`).
 
-> Phase 0 status: this document describes the intended end-state. The CLI
-> commands referenced here (`maestro init`, `maestro add`, `maestro run`) are
-> stubs in Phase 0 and become real in Phases 1-2.
+The CLI commands referenced here (`maestro init`, `maestro add`, `maestro run`)
+are real as of Phase 1. Phase 2 will add scheduling on top.
 
-## 1. Create the `.maestro/` directory
+## Pre-flight
 
-In the project's working tree:
+You need:
 
-```text
-.maestro/
-├── state.md
-├── context.md
-├── decisions.md
-├── autonomy.json
-└── journal/
-```
+- `claude` CLI on PATH, OAuth'd via `claude /login` (ADR-001).
+- `GITHUB_TOKEN` in the conductor's environment with write access to the
+  repos you'll manage. Fine-grained PATs are preferred.
+- `DEVELOPER_NAME`, `DEVELOPER_EMAIL`, `DEVELOPER_GITHUB_USERNAME` set so
+  the agent's commits use your identity.
 
-The full contract for these files is in `CLAUDE.md` (root of this repo)
-under "The .maestro/ Directory Contract".
+## 1. Initialise `.maestro/` interactively
 
-## 2. Write `context.md` (long-lived)
-
-Architecture overview, conventions, key files, gotchas. The agent reads this
-every session. Keep it ~200-500 lines. Include:
-
-- Tech stack and main entry points
-- Code style and naming conventions
-- Commit message format
-- Test commands and patterns
-- Project-specific NEVER-touch list
-- Any external systems the project integrates with
-
-## 3. Write `state.md` (immediate work)
-
-Current focus, 3-5 concrete next tasks, blockers. The agent picks one task
-per session from "Next Concrete Tasks". See `CLAUDE.md` for the section
-template.
-
-## 4. Configure `autonomy.json`
-
-```json
-{
-  "level": "pr-only",
-  "schedule": "0 */6 * * *",
-  "timeBudget": 2700,
-  "qualityGates": ["test", "lint", "typecheck"],
-  "branches": { "base": "main", "prefix": "maestro/" },
-  "github": { "prLabels": ["maestro"], "draftByDefault": false },
-  "skipDays": [],
-  "maxSessionsPerDay": 6
-}
-```
-
-`timeBudget` is in seconds. Default 2700 (45 minutes). See
-`PROJECT_CONFIG.md` for the developer's per-project decisions.
-
-## 5. Commit `.maestro/` to the project repo
-
-The directory travels with the code (ADR-004). Both your active sessions and
-Maestro's autonomous sessions read the same files.
-
-## 6. Register with Maestro
+In your project's clean working tree:
 
 ```bash
-maestro add <repo-url>
+maestro init /path/to/your/project
 ```
 
-## 7. Dry-run the first session
+The CLI:
+
+- Verifies the path is a git repo with a clean working tree.
+- Scrapes a starter `context.md` from `package.json`/`pyproject.toml`/`Cargo.toml`,
+  README excerpt, and top-level layout.
+- Asks for your current focus (1–3 sentences) and the initial 3–5 concrete tasks.
+- Asks for autonomy level, cron schedule, time budget (minutes), and quality gates.
+- Writes `.maestro/{state,context,decisions,autonomy}.{md,json}` plus an empty
+  `journal/.gitkeep`.
+- Validates everything it just wrote with the Zod schemas in `@maestro/shared`.
+
+The autonomy levels are described in `CLAUDE.md`:
+
+- `pr-only` — agent opens regular PRs, you merge. Default for most projects.
+- `draft-only` — agent opens draft PRs that explicitly need review.
+- `full` — agent commits directly to main. Reserved for low-risk projects.
+- `paused` — Maestro doesn't touch this project until unpaused.
+
+## 2. Edit `context.md` to taste
+
+The scrape is just a starting point. Open `.maestro/context.md` and add:
+
+- Architecture overview, key files, conventions
+- Commit message format (the agent follows yours, not Maestro's)
+- Project-specific NEVER list (financial code paths, auth, etc.)
+- Anything that would surprise a fresh agent
+
+Keep it ~200–500 lines. The agent reads this every session.
+
+## 3. Commit `.maestro/` to your project repo
 
 ```bash
-maestro run <project> --dry-run
+cd /path/to/your/project
+git add .maestro
+git commit -m "chore: maestro init"
+git push
 ```
 
-This prints the constructed prompt without spawning Claude. Read it. If
-anything looks off, the fix is almost always in `state.md` or `context.md`,
-not in the agent.
+The directory travels with the code (ADR-004). Both your active editor
+sessions and Maestro's autonomous sessions read the same files.
 
-## 8. Real first session
+## 4. Register the project with Maestro
 
 ```bash
-maestro run <project>
+maestro add https://github.com/<owner>/<repo>
 ```
 
-For a brand-new project the first session is intentionally orientation-only
-(see the FIRST SESSION preamble in `packages/shared/src/prompt-templates.ts`).
-The next session will start real work.
+This clones the repo to a temp directory, validates `.maestro/`, and inserts
+a `projects` row. The slug is derived from `<owner>-<repo>` lower-cased.
 
-## 9. Review the resulting PR carefully
+## 5. Dry-run the first session
+
+```bash
+maestro run <slug> --dry-run
+```
+
+This prints the exact prompt the agent will receive — without spawning Claude.
+Read it. If anything looks off, the fix is almost always in `state.md` or
+`context.md`, not in the agent.
+
+## 6. The real first session
+
+```bash
+maestro run <slug>
+```
+
+The conductor:
+
+1. Acquires the per-project lock.
+2. Refreshes its working clone under `MAESTRO_DATA_DIR/work/<slug>`.
+3. Builds the prompt from `state.md`, `context.md`, and recent journal.
+4. Spawns `claude -p` with a sandboxed working dir and the configured budget.
+5. At budget − 5 min sends SIGTERM (graceful wrap-up); at budget sends SIGTERM;
+   at budget + 30s SIGKILL.
+6. Verifies the agent committed work on a feature branch and updated
+   `state.md` + journal.
+7. Runs your quality gates (`pnpm test`, `pnpm lint`, `pnpm typecheck`, etc).
+8. If a gate fails, spawns one fixup turn (15-minute budget) and re-runs gates.
+9. If all gates pass, pushes the branch and opens a PR.
+10. If gates still fail, pushes the branch with a `quality-gates-failed` label
+    but does NOT open a PR.
+
+The whole session is logged to `MAESTRO_DATA_DIR/logs/sessions/<id>.log`.
+
+For a brand-new project the **first** session is intentionally
+orientation-only (see the FIRST SESSION preamble in
+`packages/shared/src/prompt-templates.ts`). The agent reads, explores, and
+expands `context.md` and `state.md` — it does not write code. The next
+session starts real work.
+
+## 7. Inspect what happened
+
+```bash
+maestro inspect <session-id>
+```
+
+Or open the dashboard at `http://localhost:5173` (in dev) and click the
+session.
+
+## 8. Review the PR carefully
 
 The first 2 weeks of any project are for building trust with the system.
 Review every PR. When something is wrong, update `state.md` or `context.md`
 rather than trying to "fix" the agent.
 
-## 10. Enable the schedule
+## 9. Enable the schedule (Phase 2)
 
-Once you've shipped a few good PRs from manual sessions, switch the project
-on. The schedule in `autonomy.json` takes effect on the next scheduler tick.
+Phase 1 is manual-only — you trigger every session yourself. Phase 2 wires
+`autonomy.json`'s `schedule` field to a node-cron daemon. You'll be able to
+turn that on by toggling the project from `paused` once Phase 2 lands.
+
+## Quick reference
+
+```bash
+maestro init <path>                    # scaffold .maestro/ interactively
+maestro add <repo-url>                 # register with the conductor
+maestro list                           # registered projects
+maestro run <slug> --dry-run           # print the prompt only
+maestro run <slug>                     # real session
+maestro inspect <session-id>           # session details + log tail
+maestro status                         # conductor health
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,11 @@ export default tseslint.config(
       '**/node_modules/**',
       '**/.vite/**',
       '**/coverage/**',
+      // Working clones of managed projects (created by the worker) and any
+      // local sandbox fixtures the developer keeps in the repo for testing.
+      // Their style rules are not Maestro's concern.
+      'data/**',
+      'maestro-test/**',
       '**/*.config.js',
       '**/*.config.cjs',
       '**/*.config.mjs',

--- a/package.json
+++ b/package.json
@@ -27,8 +27,13 @@
   },
   "dependencies": {
     "@maestro/api": "workspace:*",
+    "@maestro/conductor": "workspace:*",
     "@maestro/shared": "workspace:*",
-    "cac": "^6.7.14"
+    "cac": "^6.7.14",
+    "dotenv": "^16.4.7",
+    "kleur": "^4.1.5",
+    "prompts": "^2.4.2",
+    "simple-git": "^3.27.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -39,6 +44,7 @@
   "devDependencies": {
     "@eslint/js": "^9.18.0",
     "@types/node": "^22.10.5",
+    "@types/prompts": "^2.4.9",
     "@typescript-eslint/eslint-plugin": "^8.20.0",
     "@typescript-eslint/parser": "^8.20.0",
     "concurrently": "^9.1.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -b",
     "dev": "tsc -b --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@maestro/shared": "workspace:*",

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -12,6 +12,7 @@ import {
   ProjectSchema,
   SessionSchema,
   PullRequestSchema,
+  QualityGateRunSchema,
 } from '@maestro/shared'
 
 // ─── Common ──────────────────────────────────────────────────────────
@@ -58,6 +59,22 @@ export const ListSessionsResponseSchema = z.object({
   total: z.number().int().nonnegative(),
 })
 
+export const GetSessionParamsSchema = z.object({
+  id: z.string().min(1),
+})
+
+export const GetSessionResponseSchema = z.object({
+  session: SessionSchema,
+  qualityGates: z.array(QualityGateRunSchema),
+})
+
+export const SessionLogResponseSchema = z.object({
+  available: z.boolean(),
+  truncated: z.boolean(),
+  tail: z.string(),
+  sizeBytes: z.number().int().nonnegative().optional(),
+})
+
 // ─── /api/prs ────────────────────────────────────────────────────────
 
 export const ListPullRequestsQuerySchema = z.object({
@@ -79,6 +96,8 @@ export const ROUTES = {
   listProjects: { method: 'GET', path: '/api/projects' },
   getProject: { method: 'GET', path: '/api/projects/:slug' },
   listSessions: { method: 'GET', path: '/api/sessions' },
+  getSession: { method: 'GET', path: '/api/sessions/:id' },
+  getSessionLog: { method: 'GET', path: '/api/sessions/:id/log' },
   listPullRequests: { method: 'GET', path: '/api/prs' },
 } as const
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -10,6 +10,9 @@ import type {
   GetProjectResponseSchema,
   ListSessionsQuerySchema,
   ListSessionsResponseSchema,
+  GetSessionParamsSchema,
+  GetSessionResponseSchema,
+  SessionLogResponseSchema,
   ListPullRequestsQuerySchema,
   ListPullRequestsResponseSchema,
 } from './routes.js'
@@ -23,6 +26,10 @@ export type GetProjectResponse = z.infer<typeof GetProjectResponseSchema>
 
 export type ListSessionsQuery = z.infer<typeof ListSessionsQuerySchema>
 export type ListSessionsResponse = z.infer<typeof ListSessionsResponseSchema>
+
+export type GetSessionParams = z.infer<typeof GetSessionParamsSchema>
+export type GetSessionResponse = z.infer<typeof GetSessionResponseSchema>
+export type SessionLogResponse = z.infer<typeof SessionLogResponseSchema>
 
 export type ListPullRequestsQuery = z.infer<typeof ListPullRequestsQuerySchema>
 export type ListPullRequestsResponse = z.infer<typeof ListPullRequestsResponseSchema>

--- a/packages/conductor/package.json
+++ b/packages/conductor/package.json
@@ -4,13 +4,24 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
+    },
+    "./bootstrap": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -b && pnpm run copy-assets",
     "copy-assets": "node ./scripts/copy-migrations.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -18,16 +29,22 @@
     "@hono/zod-validator": "^0.4.2",
     "@maestro/api": "workspace:*",
     "@maestro/shared": "workspace:*",
+    "@octokit/rest": "^21.1.0",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^16.4.7",
+    "execa": "^9.5.2",
     "hono": "^4.6.14",
+    "p-retry": "^6.2.1",
     "pino": "^9.5.0",
     "pino-pretty": "^13.0.0",
+    "proper-lockfile": "^4.1.2",
+    "simple-git": "^3.27.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.5",
+    "@types/proper-lockfile": "^4.1.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/packages/conductor/src/claude-runner.ts
+++ b/packages/conductor/src/claude-runner.ts
@@ -1,0 +1,376 @@
+// Spawns the `claude` CLI in non-interactive mode for a single autonomous
+// session, enforces the time budget, and streams output to a session log
+// file.
+//
+// Time-budget choreography (ADR-007):
+//   T = 0                : spawn `claude -p ...`
+//   T = budget − 5 min   : send SIGTERM with a graceful note (the prompt
+//                          tells the agent to wrap up at this point)
+//   T = budget           : SIGTERM again — we expect Claude Code to honour
+//                          the wrap-up and exit
+//   T = budget + 30 s    : SIGKILL — the nuclear backstop
+//
+// Output handling: we use --output-format stream-json + --include-partial-
+// messages to get one JSON object per line. The very last object is a
+// `result` event with usage and the final text; we extract token counts
+// for cost tracking and surface the model used. The full raw stream goes
+// to the session log file unchanged.
+//
+// Auth: we deliberately DO NOT pass --bare. Bare mode bypasses the
+// keychain and forces ANTHROPIC_API_KEY, which contradicts ADR-001 (the
+// conductor uses the developer's Pro/Max OAuth credentials).
+
+import { execa, type ResultPromise } from 'execa'
+import { createWriteStream, type WriteStream } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import {
+  KILL_GRACE_SECONDS,
+  WRAP_UP_GRACE_SECONDS,
+  MaestroError,
+  type TerminationCause,
+} from '@maestro/shared'
+import { logger } from './logger.js'
+
+// ─── Public API ──────────────────────────────────────────────────────
+
+export interface ClaudeRunInput {
+  /** Working directory for the agent. Sandbox boundary. */
+  cwd: string
+  /** The constructed system+user prompt, fully baked. */
+  prompt: string
+  /** Hard kill ceiling in seconds. */
+  timeBudgetSeconds: number
+  /** Absolute path to the session log file (will be created). */
+  logPath: string
+  /** Allowed-tools list passed to claude --allowedTools. */
+  allowedTools?: string[]
+  /** Backstop dollar cap on the API spend, passed via --max-budget-usd. */
+  maxBudgetUsd?: number
+  /**
+   * Override the binary. Used by tests to point at a mock script, never in
+   * production.
+   */
+  claudeBin?: string
+  /** Whitelisted env vars to forward to the agent. PATH/HOME are auto. */
+  extraEnv?: NodeJS.ProcessEnv
+}
+
+export interface ClaudeRunResult {
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+  terminationCause: TerminationCause
+  durationMs: number
+  /** Best-effort: parsed from the final `result` line of stream-json. */
+  modelUsed: string | null
+  inputTokens: number | null
+  outputTokens: number | null
+  cacheReadTokens: number | null
+  cacheWriteTokens: number | null
+  /** Estimated cost in cents from the parsed token counts. */
+  costCents: number | null
+}
+
+const DEFAULT_ALLOWED_TOOLS = ['Read', 'Edit', 'Write', 'Bash', 'Glob', 'Grep']
+
+export async function runClaudeSession(input: ClaudeRunInput): Promise<ClaudeRunResult> {
+  await mkdir(dirname(input.logPath), { recursive: true })
+  const logStream = createWriteStream(input.logPath, { flags: 'w' })
+
+  const args = buildArgs(input)
+  const start = Date.now()
+
+  logger.info(
+    {
+      cwd: input.cwd,
+      timeBudget: input.timeBudgetSeconds,
+      logPath: input.logPath,
+      argv: redactArgs(args),
+    },
+    'spawning claude session',
+  )
+
+  const child = execa(input.claudeBin ?? 'claude', args, {
+    cwd: input.cwd,
+    env: claudeEnv(input.extraEnv),
+    input: input.prompt,
+    reject: false,
+    // We pipe stdin ourselves above. stdout/stderr go to the log file.
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+
+  const captured: string[] = []
+  pipeWithCapture(child.stdout, logStream, captured, 'stdout')
+  pipeWithCapture(child.stderr, logStream, captured, 'stderr')
+
+  const timers = scheduleBudgetSignals(child, input.timeBudgetSeconds)
+  let terminationCause: TerminationCause | null = null
+
+  const result = await child.catch((err: unknown) => err as Error)
+  for (const t of timers.list) clearTimeout(t)
+
+  if (timers.cause) terminationCause = timers.cause
+  await flushAndClose(logStream)
+
+  const durationMs = Date.now() - start
+  const exitInfo = extractExit(result)
+
+  if (!terminationCause) {
+    if (exitInfo.exitCode === 0) terminationCause = 'exit-clean'
+    else if (exitInfo.signal) terminationCause = 'killed-by-signal'
+    else terminationCause = 'failed'
+  }
+
+  const meta = parseFinalResultLine(captured.join(''))
+
+  return {
+    exitCode: exitInfo.exitCode,
+    signal: exitInfo.signal,
+    terminationCause,
+    durationMs,
+    modelUsed: meta.model,
+    inputTokens: meta.inputTokens,
+    outputTokens: meta.outputTokens,
+    cacheReadTokens: meta.cacheReadTokens,
+    cacheWriteTokens: meta.cacheWriteTokens,
+    costCents: meta.costCents,
+  }
+}
+
+// ─── Internals ───────────────────────────────────────────────────────
+
+function buildArgs(input: ClaudeRunInput): string[] {
+  const tools = (input.allowedTools ?? DEFAULT_ALLOWED_TOOLS).join(' ')
+  const args = [
+    '-p',
+    '--permission-mode',
+    'bypassPermissions',
+    '--allowedTools',
+    tools,
+    '--no-session-persistence',
+    '--output-format',
+    'stream-json',
+    '--include-partial-messages',
+    '--verbose', // stream-json requires --verbose
+    '--add-dir',
+    input.cwd,
+  ]
+  if (input.maxBudgetUsd !== undefined) {
+    args.push('--max-budget-usd', String(input.maxBudgetUsd))
+  }
+  // The prompt comes from stdin; passing as an arg risks exceeding ARG_MAX
+  // for long context. Claude Code reads stdin when no positional prompt is
+  // provided alongside `-p`. We confirm via tests in mock-claude.
+  return args
+}
+
+function pipeWithCapture(
+  source: NodeJS.ReadableStream | null | undefined,
+  sink: WriteStream,
+  buffer: string[],
+  channel: 'stdout' | 'stderr',
+): void {
+  if (!source) return
+  source.on('data', (chunk: Buffer | string) => {
+    const text = chunk.toString()
+    buffer.push(text)
+    sink.write(channel === 'stderr' ? `[stderr] ${text}` : text)
+  })
+}
+
+interface BudgetTimers {
+  list: NodeJS.Timeout[]
+  cause: TerminationCause | null
+}
+
+function scheduleBudgetSignals(
+  child: ResultPromise<{ reject: false }>,
+  budgetSeconds: number,
+): BudgetTimers {
+  const state: BudgetTimers = { list: [], cause: null }
+  const sigtermAtBudget = budgetSeconds * 1000
+  const sigkillAt = sigtermAtBudget + KILL_GRACE_SECONDS * 1000
+
+  // Only schedule the graceful wrap-up signal when there's enough headroom
+  // for it to be useful. For very short budgets (tests, fast iteration)
+  // we skip directly to the at-budget SIGTERM so we don't kill the agent
+  // before it's even started.
+  if (budgetSeconds > WRAP_UP_GRACE_SECONDS + 30) {
+    const wrapUpAt = (budgetSeconds - WRAP_UP_GRACE_SECONDS) * 1000
+    state.list.push(
+      setTimeout(() => {
+        logger.warn(
+          { budgetSeconds, deadlineSeconds: WRAP_UP_GRACE_SECONDS },
+          'budget − 5min: SIGTERM (graceful wrap-up)',
+        )
+        try {
+          child.kill('SIGTERM')
+          if (!state.cause) state.cause = 'graceful'
+        } catch {
+          /* already exited */
+        }
+      }, wrapUpAt),
+    )
+  }
+
+  state.list.push(
+    setTimeout(() => {
+      logger.warn({ budgetSeconds }, 'budget reached: SIGTERM')
+      try {
+        child.kill('SIGTERM')
+        state.cause = 'sigterm-timeout'
+      } catch {
+        /* already exited */
+      }
+    }, sigtermAtBudget),
+  )
+
+  state.list.push(
+    setTimeout(() => {
+      logger.error({ budgetSeconds }, 'budget + 30s: SIGKILL')
+      try {
+        child.kill('SIGKILL')
+        state.cause = 'sigkill-timeout'
+      } catch {
+        /* already exited */
+      }
+    }, sigkillAt),
+  )
+
+  return state
+}
+
+interface ExitInfo {
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+}
+
+function extractExit(result: unknown): ExitInfo {
+  if (result && typeof result === 'object') {
+    const r = result as { exitCode?: number; signal?: NodeJS.Signals }
+    return {
+      exitCode: typeof r.exitCode === 'number' ? r.exitCode : null,
+      signal: r.signal ?? null,
+    }
+  }
+  return { exitCode: null, signal: null }
+}
+
+interface ParsedResultMeta {
+  model: string | null
+  inputTokens: number | null
+  outputTokens: number | null
+  cacheReadTokens: number | null
+  cacheWriteTokens: number | null
+  costCents: number | null
+}
+
+/**
+ * Walk the captured stream-json output backward to find the final
+ * `result` event. Robust to partial-message lines being interleaved.
+ */
+function parseFinalResultLine(captured: string): ParsedResultMeta {
+  const empty: ParsedResultMeta = {
+    model: null,
+    inputTokens: null,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    costCents: null,
+  }
+  if (!captured) return empty
+  const lines = captured.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim()
+    if (!line || !line.startsWith('{')) continue
+    try {
+      const obj = JSON.parse(line) as Record<string, unknown>
+      if (obj['type'] === 'result' || obj['type'] === 'session_result') {
+        return readUsage(obj)
+      }
+    } catch {
+      // Not a complete JSON object (likely a partial-message frame). Skip.
+    }
+  }
+  return empty
+}
+
+function readUsage(obj: Record<string, unknown>): ParsedResultMeta {
+  const usage = (obj['usage'] ?? null) as Record<string, unknown> | null
+  const model = typeof obj['model'] === 'string' ? (obj['model'] as string) : null
+  const input = numOrNull(usage?.['input_tokens'])
+  const output = numOrNull(usage?.['output_tokens'])
+  const cacheRead = numOrNull(usage?.['cache_read_input_tokens'])
+  const cacheWrite = numOrNull(usage?.['cache_creation_input_tokens'])
+
+  // Per the rate card surfaced by `claude --help` / docs:
+  //   $3   per 1M input
+  //   $15  per 1M output
+  //   $3.75 per 1M cache write
+  //   $0.30 per 1M cache read
+  // Compute as cents (integer).
+  const costCents =
+    input !== null && output !== null
+      ? Math.round(
+          ((input ?? 0) * 0.0003 +
+            (output ?? 0) * 0.0015 +
+            (cacheRead ?? 0) * 0.00003 +
+            (cacheWrite ?? 0) * 0.000375) /
+            10,
+        )
+      : null
+
+  return {
+    model,
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: cacheWrite,
+    costCents,
+  }
+}
+
+function numOrNull(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+function redactArgs(args: string[]): string[] {
+  return args.map((a) => (a.length > 200 ? `${a.slice(0, 100)}…` : a))
+}
+
+function flushAndClose(stream: WriteStream): Promise<void> {
+  return new Promise((resolve) => {
+    stream.end(resolve)
+  })
+}
+
+/** Whitelisted env for the agent. Mirrors quality-gates.cleanEnv. */
+function claudeEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const allow = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TERM', 'SHELL', 'TMPDIR']
+  const out: NodeJS.ProcessEnv = {}
+  for (const key of allow) {
+    const value = process.env[key]
+    if (value !== undefined) out[key] = value
+  }
+  if (process.env['CI']) out['CI'] = process.env['CI']
+  // ANTHROPIC_API_KEY only forwarded if explicitly opted-in via extraEnv.
+  Object.assign(out, extra ?? {})
+  return out
+}
+
+/** Throws if the `claude` binary cannot be located. */
+export async function ensureClaudeAvailable(claudeBin = 'claude'): Promise<void> {
+  try {
+    const r = await execa(claudeBin, ['--version'], { reject: false, timeout: 5000 })
+    if (r.exitCode !== 0) {
+      throw new Error(`claude --version exit ${r.exitCode}`)
+    }
+  } catch (err) {
+    throw new MaestroError('SESSION_SPAWN_FAILED', {
+      message:
+        'Claude Code CLI not found or not authenticated. Install it and run `claude /login` once.',
+      cause: err,
+      context: { claudeBin },
+    })
+  }
+}

--- a/packages/conductor/src/db/migrations/002_phase1_session_columns.sql
+++ b/packages/conductor/src/db/migrations/002_phase1_session_columns.sql
@@ -1,0 +1,30 @@
+-- Phase 1 session columns.
+--
+-- Adds the fields the worker writes after a real session: which model the
+-- agent ran, how it terminated, the on-disk log path, the PR URL (so the
+-- dashboard can deep-link without rebuilding it from project + number),
+-- and a parent_session_id link so a fixup turn references its parent.
+
+ALTER TABLE sessions ADD COLUMN model_used        TEXT;
+ALTER TABLE sessions ADD COLUMN pr_url            TEXT;
+ALTER TABLE sessions ADD COLUMN log_path          TEXT;
+ALTER TABLE sessions ADD COLUMN termination_cause TEXT
+  CHECK (termination_cause IS NULL OR termination_cause IN (
+    'exit-clean','graceful','sigterm-timeout','sigkill-timeout','failed','killed-by-signal'
+  ));
+ALTER TABLE sessions ADD COLUMN is_fixup_turn     INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN parent_session_id TEXT
+  REFERENCES sessions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+  ON sessions(parent_session_id);
+
+-- Per-project advisory locks. SQLite has no native session locks; we use a
+-- table with a UNIQUE project_id and INSERT OR ABORT to acquire. ADR-008
+-- guarantees per-project sequential execution.
+CREATE TABLE IF NOT EXISTS project_locks (
+  project_id  TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+  session_id  TEXT NOT NULL,
+  acquired_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  pid         INTEGER NOT NULL
+);

--- a/packages/conductor/src/index.ts
+++ b/packages/conductor/src/index.ts
@@ -21,10 +21,14 @@ async function main(): Promise<void> {
 
   const dbHandle = openDatabase({ dataDir: config.dataDir })
   const startedAt = Date.now()
-  const app = buildServer({ startedAt, version: PACKAGE_VERSION })
+  const app = buildServer({ startedAt, version: PACKAGE_VERSION, db: dbHandle.db })
 
-  // Phase-deferred subsystems. These are no-ops in Phase 0 — they exist so
-  // wiring is in place for Phase 2 (scheduling) and Phase 4 (briefings).
+  // Reclaim any stale per-project locks left behind by a previous crash.
+  const { ProjectLockManager } = await import('./locks.js')
+  const stale = new ProjectLockManager(dbHandle.db).releaseAllForCurrentProcess()
+  if (stale > 0) logger.warn({ stale }, 'reclaimed stale project locks')
+
+  // Phase-deferred subsystems (Phase 2 scheduling, Phase 4 briefings).
   startScheduler({ db: dbHandle.db, config })
   startBriefing({ db: dbHandle.db, config })
 

--- a/packages/conductor/src/lib.ts
+++ b/packages/conductor/src/lib.ts
@@ -1,0 +1,19 @@
+// Programmatic API surface for the conductor package.
+//
+// The CLI and tests import from `@maestro/conductor`. The actual server
+// bootstrap lives in `index.ts` and is invoked via `node dist/index.js`,
+// not via package import — so this barrel can re-export server pieces
+// without triggering `main()`.
+
+export * from './config.js'
+export * from './db.js'
+export * from './logger.js'
+export * from './locks.js'
+export * from './repositories.js'
+export * from './state-manager.js'
+export * from './stack-detector.js'
+export * from './quality-gates.js'
+export * from './claude-runner.js'
+export * from './pr-manager.js'
+export * from './worker.js'
+export { buildServer, type ServerDeps } from './server.js'

--- a/packages/conductor/src/locks.ts
+++ b/packages/conductor/src/locks.ts
@@ -1,0 +1,86 @@
+// Per-project advisory locks (ADR-008). Two sessions for the same project
+// must never run concurrently — that's the only way to keep the working
+// directory and `.maestro/` state coherent.
+//
+// SQLite has no native session locks, so we model one with a row per
+// project keyed on project_id. Acquire = INSERT; release = DELETE. The
+// PRIMARY KEY on project_id makes acquire atomic.
+//
+// Locks include the holder's pid; if the conductor restarts mid-session
+// we can reclaim a lock whose holder is gone.
+
+import type Database from 'better-sqlite3'
+import { MaestroError } from '@maestro/shared'
+
+interface LockRow {
+  project_id: string
+  session_id: string
+  acquired_at: string
+  pid: number
+}
+
+export class ProjectLockManager {
+  constructor(private readonly db: Database.Database) {}
+
+  /**
+   * Try to acquire the lock for `projectId`. Returns true on success.
+   * Throws PROJECT_LOCKED if another live process holds the lock.
+   */
+  acquire(projectId: string, sessionId: string): void {
+    const existing = this.peek(projectId)
+    if (existing) {
+      if (isProcessAlive(existing.pid)) {
+        throw new MaestroError('PROJECT_LOCKED', {
+          message: `Project is locked by session ${existing.session_id} (pid ${existing.pid})`,
+          context: { projectId, holderSessionId: existing.session_id, pid: existing.pid },
+        })
+      }
+      // Stale — the previous holder is gone. Reclaim.
+      this.db.prepare('DELETE FROM project_locks WHERE project_id = ?').run(projectId)
+    }
+    try {
+      this.db
+        .prepare('INSERT INTO project_locks (project_id, session_id, pid) VALUES (?, ?, ?)')
+        .run(projectId, sessionId, process.pid)
+    } catch (err) {
+      throw new MaestroError('PROJECT_LOCKED', {
+        message: 'Race acquiring project lock',
+        cause: err,
+        context: { projectId, sessionId },
+      })
+    }
+  }
+
+  release(projectId: string, sessionId: string): void {
+    this.db
+      .prepare('DELETE FROM project_locks WHERE project_id = ? AND session_id = ?')
+      .run(projectId, sessionId)
+  }
+
+  /**
+   * Drop any locks held by THIS process. Used at startup so a crashed
+   * conductor doesn't leave behind a permanently-held lock.
+   */
+  releaseAllForCurrentProcess(): number {
+    const result = this.db.prepare('DELETE FROM project_locks WHERE pid = ?').run(process.pid)
+    return result.changes
+  }
+
+  peek(projectId: string): LockRow | null {
+    const row = this.db
+      .prepare<[string], LockRow>('SELECT * FROM project_locks WHERE project_id = ?')
+      .get(projectId)
+    return row ?? null
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 is the standard "is this pid alive" probe on POSIX. Throws
+    // if the pid doesn't exist; succeeds (with no signal sent) if it does.
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/conductor/src/pr-manager.ts
+++ b/packages/conductor/src/pr-manager.ts
@@ -1,11 +1,36 @@
-// GitHub PR operations. Wraps Octokit. Phase 1 work (see PRODUCT_VISION.md
-// "Phase 1: Manual Single-Project Sessions"). The Phase 0 file is a stub.
+// GitHub PR operations. Thin Octokit wrapper with retry/backoff for rate
+// limits and a one-time scope check on first use.
+//
+// Tests must NOT hit GitHub. Production code paths construct their own
+// Octokit (via `createGitHubClient`); tests inject a mock that conforms to
+// `GitHubClient`.
 
-import type { Project, PullRequest } from '@maestro/shared'
-import { MaestroError } from '@maestro/shared'
+import { Octokit } from '@octokit/rest'
+import pRetry, { AbortError } from 'p-retry'
+import {
+  MaestroError,
+  PullRequestSchema,
+  type Project,
+  type PullRequest,
+} from '@maestro/shared'
+import { logger } from './logger.js'
 
-export interface OpenPullRequestInput {
-  project: Project
+// ─── Public types ────────────────────────────────────────────────────
+
+export interface GitHubClient {
+  createPullRequest(input: CreatePullRequestInput): Promise<PullRequest>
+  addLabels(input: AddLabelsInput): Promise<void>
+  listOpenPullRequests(repo: RepoCoords): Promise<PullRequest[]>
+  verifyScopes(): Promise<void>
+}
+
+export interface RepoCoords {
+  owner: string
+  repo: string
+}
+
+export interface CreatePullRequestInput {
+  repo: RepoCoords
   branchName: string
   baseBranch: string
   title: string
@@ -14,8 +39,213 @@ export interface OpenPullRequestInput {
   labels?: string[]
 }
 
-export async function openPullRequest(_input: OpenPullRequestInput): Promise<PullRequest> {
-  throw new MaestroError('INTERNAL_ERROR', {
-    message: 'openPullRequest is Phase 1 work. See PRODUCT_VISION.md.',
+export interface AddLabelsInput {
+  repo: RepoCoords
+  prNumber: number
+  labels: string[]
+}
+
+// ─── Construction ────────────────────────────────────────────────────
+
+export interface CreateGitHubClientInput {
+  token: string
+  /** Optional override for tests. */
+  octokitFactory?: (token: string) => Octokit
+}
+
+export function createGitHubClient(input: CreateGitHubClientInput): GitHubClient {
+  const octokit = input.octokitFactory
+    ? input.octokitFactory(input.token)
+    : new Octokit({ auth: input.token, userAgent: 'maestro/0.0.0' })
+
+  return {
+    async createPullRequest(req) {
+      return runWithRetry(async () => {
+        const { data } = await octokit.pulls.create({
+          owner: req.repo.owner,
+          repo: req.repo.repo,
+          head: req.branchName,
+          base: req.baseBranch,
+          title: req.title,
+          body: req.body,
+          draft: req.draft ?? false,
+        })
+
+        if (req.labels && req.labels.length > 0) {
+          await octokit.issues.addLabels({
+            owner: req.repo.owner,
+            repo: req.repo.repo,
+            issue_number: data.number,
+            labels: req.labels,
+          })
+        }
+
+        return PullRequestSchema.parse({
+          number: data.number,
+          url: data.html_url,
+          title: data.title,
+          body: data.body ?? '',
+          status: data.draft ? 'draft' : 'open',
+          branchName: data.head.ref,
+          baseBranch: data.base.ref,
+          createdAt: data.created_at,
+          mergedAt: data.merged_at ?? null,
+          sessionId: null,
+        })
+      }, 'createPullRequest')
+    },
+
+    async addLabels(req) {
+      await runWithRetry(async () => {
+        await octokit.issues.addLabels({
+          owner: req.repo.owner,
+          repo: req.repo.repo,
+          issue_number: req.prNumber,
+          labels: req.labels,
+        })
+      }, 'addLabels')
+    },
+
+    async listOpenPullRequests(repo) {
+      return runWithRetry(async () => {
+        const { data } = await octokit.pulls.list({
+          owner: repo.owner,
+          repo: repo.repo,
+          state: 'open',
+          per_page: 100,
+        })
+        return data.map((pr) =>
+          PullRequestSchema.parse({
+            number: pr.number,
+            url: pr.html_url,
+            title: pr.title,
+            body: pr.body ?? '',
+            status: pr.draft ? 'draft' : 'open',
+            branchName: pr.head.ref,
+            baseBranch: pr.base.ref,
+            createdAt: pr.created_at,
+            mergedAt: pr.merged_at ?? null,
+            sessionId: null,
+          }),
+        )
+      }, 'listOpenPullRequests')
+    },
+
+    async verifyScopes() {
+      try {
+        // The token's scopes come back in the response headers from a
+        // simple `get authenticated user` call.
+        const res = await octokit.users.getAuthenticated()
+        const scopes = (res.headers['x-oauth-scopes'] ?? '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+        // Fine-grained PATs return an empty x-oauth-scopes; only classic
+        // tokens populate it. We treat empty as "fine-grained, trust it".
+        if (scopes.length > 0 && !scopes.some((s) => s === 'repo' || s === 'public_repo')) {
+          throw new MaestroError('GITHUB_API_FAILED', {
+            message: 'GitHub token is missing the `repo` scope',
+            context: { scopes },
+          })
+        }
+        logger.debug({ scopes, login: res.data.login }, 'github token verified')
+      } catch (err) {
+        if (err instanceof MaestroError) throw err
+        throw new MaestroError('GITHUB_API_FAILED', {
+          message: 'Failed to verify GitHub token scopes',
+          cause: err,
+        })
+      }
+    },
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Parse "https://github.com/owner/repo[.git]" or "git@github.com:owner/repo"
+ * into RepoCoords. Also accepts "file://" URLs (returns synthetic
+ * `local`/<basename> coordinates) so test harnesses can exercise the
+ * worker against bare local repos. Throws on anything else.
+ */
+export function parseRepoUrl(url: string): RepoCoords {
+  const trimmed = url.trim().replace(/\.git$/, '')
+  const httpsMatch = /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)\/?$/.exec(trimmed)
+  if (httpsMatch?.[1] && httpsMatch[2]) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] }
+  }
+  const sshMatch = /^git@github\.com:([^/]+)\/([^/]+?)\/?$/.exec(trimmed)
+  if (sshMatch?.[1] && sshMatch[2]) {
+    return { owner: sshMatch[1], repo: sshMatch[2] }
+  }
+  const fileMatch = /^file:\/\/(.+)$/.exec(trimmed)
+  if (fileMatch?.[1]) {
+    const segments = fileMatch[1].split('/').filter(Boolean)
+    const basename = segments[segments.length - 1] ?? 'local'
+    return { owner: 'local', repo: basename }
+  }
+  throw new MaestroError('CONFIG_VALIDATION_FAILED', {
+    message: `Repository URL does not look like a GitHub URL: ${url}`,
+    context: { url },
+  })
+}
+
+export function repoCoordsForProject(project: Project): RepoCoords {
+  return parseRepoUrl(project.repoUrl)
+}
+
+async function runWithRetry<T>(fn: () => Promise<T>, op: string): Promise<T> {
+  return pRetry(
+    async () => {
+      try {
+        return await fn()
+      } catch (err) {
+        if (isRateLimit(err)) {
+          logger.warn({ op }, 'github rate limited, will retry')
+          throw err // p-retry retries
+        }
+        // Other errors are abort-worthy — most GitHub failures are not
+        // transient.
+        throw new AbortError(err instanceof Error ? err.message : String(err))
+      }
+    },
+    { retries: 3, factor: 2, minTimeout: 2000, maxTimeout: 30000 },
+  )
+}
+
+function isRateLimit(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { status?: number; message?: string }
+  if (e.status === 403 || e.status === 429) {
+    if (typeof e.message === 'string' && /rate limit/i.test(e.message)) return true
+  }
+  return false
+}
+
+// ─── Backwards-compat shim ───────────────────────────────────────────
+
+// Older code in PRs imported `openPullRequest` directly. Keep it for now
+// so the worker can call it without ceremony; production callers should
+// prefer `createGitHubClient(...).createPullRequest(...)`.
+export interface OpenPullRequestInput {
+  project: Project
+  branchName: string
+  baseBranch: string
+  title: string
+  body: string
+  draft?: boolean
+  labels?: string[]
+  client: GitHubClient
+}
+
+export async function openPullRequest(input: OpenPullRequestInput): Promise<PullRequest> {
+  return input.client.createPullRequest({
+    repo: repoCoordsForProject(input.project),
+    branchName: input.branchName,
+    baseBranch: input.baseBranch,
+    title: input.title,
+    body: input.body,
+    draft: input.draft ?? false,
+    labels: input.labels ?? [],
   })
 }

--- a/packages/conductor/src/quality-gates.ts
+++ b/packages/conductor/src/quality-gates.ts
@@ -1,21 +1,151 @@
-// Quality gate runners. Phase 1 work (see PRODUCT_VISION.md). Per ADR-006:
-// gates run after the agent commits, before PR creation. If any gate fails,
-// the branch is preserved but no PR opens.
+// Quality gate runners. ADR-006: gates run after the agent commits, before
+// PR creation. If any gate fails, the branch is preserved but no PR opens
+// (the worker may then spawn a fixup turn before giving up).
+//
+// Each gate is invoked via execa with explicit array args — never a shell
+// string. This is security-critical because project slugs and branch
+// names eventually flow through these calls.
 
-import type { QualityGate, QualityGateRun } from '@maestro/shared'
-import { MaestroError } from '@maestro/shared'
+import { execa, type ExecaError } from 'execa'
+import {
+  DEFAULT_QUALITY_GATE_TIMEOUT_SECONDS,
+  QUALITY_GATE_OUTPUT_TAIL_LINES,
+  type QualityGate,
+  type QualityGateCommand,
+  type QualityGateStatus,
+} from '@maestro/shared'
+import { detectStack } from './stack-detector.js'
+import { logger } from './logger.js'
 
-export interface RunQualityGatesInput {
-  /** Absolute path to the working checkout. */
+export interface RunGatesInput {
+  /** Absolute path to the project working checkout. */
   projectRoot: string
-  sessionId: string
+  /** Sequence of gates to run. Order is respected. */
   gates: QualityGate[]
+  /** Per-gate timeout in seconds. Default 5 min. */
+  timeoutSeconds?: number
 }
 
-export async function runQualityGates(
-  _input: RunQualityGatesInput,
-): Promise<QualityGateRun[]> {
-  throw new MaestroError('INTERNAL_ERROR', {
-    message: 'runQualityGates is Phase 1 work. See PRODUCT_VISION.md.',
-  })
+export interface SingleGateResult {
+  gate: QualityGate
+  status: QualityGateStatus
+  /** Last N lines of combined stdout/stderr. */
+  output: string
+  /** Full output (stdout+stderr) for the session log. */
+  fullOutput: string
+  durationMs: number
+  /** Argv used; useful for journal entries and debugging. */
+  command: QualityGateCommand | null
+}
+
+export interface RunGatesResult {
+  results: SingleGateResult[]
+  allPassed: boolean
+}
+
+export async function runQualityGates(input: RunGatesInput): Promise<RunGatesResult> {
+  const stack = await detectStack(input.projectRoot)
+  const timeoutMs = (input.timeoutSeconds ?? DEFAULT_QUALITY_GATE_TIMEOUT_SECONDS) * 1000
+
+  const results: SingleGateResult[] = []
+  let allPassed = true
+
+  for (const gate of input.gates) {
+    const command = stack.gates[gate]
+    if (!command) {
+      logger.warn(
+        { gate, stack: stack.stack, projectRoot: input.projectRoot },
+        'no command resolved for gate — skipping',
+      )
+      results.push({
+        gate,
+        status: 'skipped',
+        output: `(no command available for gate "${gate}" on stack "${stack.stack}")`,
+        fullOutput: '',
+        durationMs: 0,
+        command: null,
+      })
+      continue
+    }
+    const result = await runOneGate({ gate, command, cwd: input.projectRoot, timeoutMs })
+    results.push(result)
+    if (result.status === 'failed') allPassed = false
+  }
+
+  return { results, allPassed }
+}
+
+interface RunOneGateInput {
+  gate: QualityGate
+  command: QualityGateCommand
+  cwd: string
+  timeoutMs: number
+}
+
+async function runOneGate(input: RunOneGateInput): Promise<SingleGateResult> {
+  const start = Date.now()
+  let stdout = ''
+  let stderr = ''
+  let status: QualityGateStatus = 'passed'
+
+  try {
+    const sub = execa(input.command.command, input.command.args, {
+      cwd: input.cwd,
+      timeout: input.timeoutMs,
+      reject: false,
+      env: cleanEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    sub.stdout?.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString()
+    })
+    sub.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString()
+    })
+
+    const result = await sub
+    if (result.failed) status = 'failed'
+    if (result.timedOut) status = 'failed'
+  } catch (err) {
+    status = 'failed'
+    const execErr = err as ExecaError
+    if (execErr.stderr) stderr += String(execErr.stderr)
+    if (execErr.stdout) stdout += String(execErr.stdout)
+  }
+
+  const durationMs = Date.now() - start
+  const fullOutput = stdout + (stderr ? `\n[stderr]\n${stderr}` : '')
+  return {
+    gate: input.gate,
+    status,
+    output: tail(fullOutput, QUALITY_GATE_OUTPUT_TAIL_LINES),
+    fullOutput,
+    durationMs,
+    command: input.command,
+  }
+}
+
+function tail(s: string, lines: number): string {
+  if (!s) return ''
+  const arr = s.split('\n')
+  if (arr.length <= lines) return s
+  return arr.slice(-lines).join('\n')
+}
+
+/**
+ * The agent's working directory must NOT see the conductor's developer
+ * shell — that's the path most likely to leak the GITHUB_TOKEN, dotfiles,
+ * or other secrets. We pass through a small safe whitelist plus PATH so
+ * tools like `pnpm`, `tsc`, etc. are findable.
+ */
+function cleanEnv(): NodeJS.ProcessEnv {
+  const allow = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TERM', 'SHELL', 'TMPDIR']
+  const out: NodeJS.ProcessEnv = {}
+  for (const key of allow) {
+    const value = process.env[key]
+    if (value !== undefined) out[key] = value
+  }
+  if (process.env['CI']) out['CI'] = process.env['CI']
+  return out
 }

--- a/packages/conductor/src/repositories.ts
+++ b/packages/conductor/src/repositories.ts
@@ -1,0 +1,297 @@
+// SQLite repositories for projects, sessions, quality gates, and per-project
+// advisory locks. The conductor's "operational" data store. The .maestro/
+// files in each managed repo remain the source of truth for project state
+// (ADR-003); SQLite tracks runs, costs, and lock ownership.
+
+import type Database from 'better-sqlite3'
+import {
+  ProjectSchema,
+  SessionSchema,
+  QualityGateRunSchema,
+  type Project,
+  type ProjectAutonomyConfig,
+  type Session,
+  type SessionStatus,
+  type TerminationCause,
+  type QualityGateRun,
+  type QualityGate,
+  type QualityGateStatus,
+  MaestroError,
+} from '@maestro/shared'
+
+// ─── Projects ────────────────────────────────────────────────────────
+
+interface ProjectRow {
+  id: string
+  slug: string
+  repo_url: string
+  autonomy_config_json: string
+  created_at: string
+}
+
+export interface CreateProjectInput {
+  id: string
+  slug: string
+  repoUrl: string
+  autonomyConfig: ProjectAutonomyConfig
+}
+
+export class ProjectRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: CreateProjectInput): Project {
+    const stmt = this.db.prepare(`
+      INSERT INTO projects (id, slug, repo_url, autonomy_config_json)
+      VALUES (?, ?, ?, ?)
+    `)
+    try {
+      stmt.run(input.id, input.slug, input.repoUrl, JSON.stringify(input.autonomyConfig))
+    } catch (err) {
+      throw new MaestroError('CONFIG_VALIDATION_FAILED', {
+        message: `Failed to insert project ${input.slug}`,
+        cause: err,
+        context: { slug: input.slug },
+      })
+    }
+    const row = this.findBySlug(input.slug)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'project insert succeeded but row missing' })
+    return row
+  }
+
+  findBySlug(slug: string): Project | null {
+    const row = this.db
+      .prepare<[string], ProjectRow>('SELECT * FROM projects WHERE slug = ?')
+      .get(slug)
+    return row ? rowToProject(row) : null
+  }
+
+  findById(id: string): Project | null {
+    const row = this.db
+      .prepare<[string], ProjectRow>('SELECT * FROM projects WHERE id = ?')
+      .get(id)
+    return row ? rowToProject(row) : null
+  }
+
+  list(): Project[] {
+    const rows = this.db
+      .prepare<[], ProjectRow>('SELECT * FROM projects ORDER BY created_at DESC')
+      .all()
+    return rows.map(rowToProject)
+  }
+
+  delete(slug: string): void {
+    this.db.prepare('DELETE FROM projects WHERE slug = ?').run(slug)
+  }
+}
+
+function rowToProject(row: ProjectRow): Project {
+  return ProjectSchema.parse({
+    id: row.id,
+    slug: row.slug,
+    repoUrl: row.repo_url,
+    autonomyConfig: JSON.parse(row.autonomy_config_json) as unknown,
+    createdAt: row.created_at,
+  })
+}
+
+// ─── Sessions ────────────────────────────────────────────────────────
+
+interface SessionRow {
+  id: string
+  project_id: string
+  status: SessionStatus
+  started_at: string
+  ended_at: string | null
+  cost_cents: number | null
+  prompt_version: string
+  model_used: string | null
+  branch_name: string | null
+  pr_number: number | null
+  pr_url: string | null
+  journal_path: string | null
+  log_path: string | null
+  termination_cause: TerminationCause | null
+  is_fixup_turn: number
+  parent_session_id: string | null
+}
+
+export interface CreateSessionInput {
+  id: string
+  projectId: string
+  promptVersion: string
+  isFixupTurn?: boolean
+  parentSessionId?: string | null
+}
+
+export interface UpdateSessionInput {
+  status?: SessionStatus
+  endedAt?: string | null
+  costCents?: number | null
+  modelUsed?: string | null
+  branchName?: string | null
+  prNumber?: number | null
+  prUrl?: string | null
+  journalPath?: string | null
+  logPath?: string | null
+  terminationCause?: TerminationCause | null
+}
+
+export class SessionRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: CreateSessionInput): Session {
+    const startedAt = new Date().toISOString()
+    this.db
+      .prepare(
+        `INSERT INTO sessions (id, project_id, status, started_at, prompt_version, is_fixup_turn, parent_session_id)
+         VALUES (?, ?, 'pending', ?, ?, ?, ?)`,
+      )
+      .run(
+        input.id,
+        input.projectId,
+        startedAt,
+        input.promptVersion,
+        input.isFixupTurn ? 1 : 0,
+        input.parentSessionId ?? null,
+      )
+    const row = this.findById(input.id)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'session insert lost' })
+    return row
+  }
+
+  update(id: string, patch: UpdateSessionInput): Session {
+    const setParts: string[] = []
+    const values: Array<string | number | null> = []
+    const map: Record<string, keyof UpdateSessionInput> = {
+      status: 'status',
+      ended_at: 'endedAt',
+      cost_cents: 'costCents',
+      model_used: 'modelUsed',
+      branch_name: 'branchName',
+      pr_number: 'prNumber',
+      pr_url: 'prUrl',
+      journal_path: 'journalPath',
+      log_path: 'logPath',
+      termination_cause: 'terminationCause',
+    }
+    for (const column of Object.keys(map)) {
+      const key = map[column]
+      if (key === undefined) continue
+      const value = patch[key]
+      if (value === undefined) continue
+      setParts.push(`${column} = ?`)
+      values.push(value)
+    }
+    if (setParts.length === 0) {
+      const existing = this.findById(id)
+      if (!existing) throw new MaestroError('INTERNAL_ERROR', { message: `session ${id} missing` })
+      return existing
+    }
+    values.push(id)
+    this.db.prepare(`UPDATE sessions SET ${setParts.join(', ')} WHERE id = ?`).run(...values)
+    const row = this.findById(id)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: `session ${id} missing after update` })
+    return row
+  }
+
+  findById(id: string): Session | null {
+    const row = this.db
+      .prepare<[string], SessionRow>('SELECT * FROM sessions WHERE id = ?')
+      .get(id)
+    return row ? rowToSession(row) : null
+  }
+
+  list(opts: { projectId?: string; limit?: number; offset?: number } = {}): {
+    sessions: Session[]
+    total: number
+  } {
+    const where = opts.projectId ? 'WHERE project_id = ?' : ''
+    const params = opts.projectId ? [opts.projectId] : []
+    const total = (
+      this.db
+        .prepare<typeof params, { count: number }>(`SELECT COUNT(*) AS count FROM sessions ${where}`)
+        .get(...params) as { count: number }
+    ).count
+    const limit = opts.limit ?? 50
+    const offset = opts.offset ?? 0
+    const rows = this.db
+      .prepare<[...typeof params, number, number], SessionRow>(
+        `SELECT * FROM sessions ${where} ORDER BY started_at DESC LIMIT ? OFFSET ?`,
+      )
+      .all(...params, limit, offset)
+    return { sessions: rows.map(rowToSession), total }
+  }
+}
+
+function rowToSession(row: SessionRow): Session {
+  return SessionSchema.parse({
+    id: row.id,
+    projectId: row.project_id,
+    status: row.status,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    costCents: row.cost_cents,
+    promptVersion: row.prompt_version,
+    modelUsed: row.model_used,
+    branchName: row.branch_name,
+    prNumber: row.pr_number,
+    prUrl: row.pr_url,
+    journalPath: row.journal_path,
+    logPath: row.log_path,
+    terminationCause: row.termination_cause,
+    isFixupTurn: row.is_fixup_turn === 1,
+    parentSessionId: row.parent_session_id,
+  })
+}
+
+// ─── Quality gate runs ───────────────────────────────────────────────
+
+interface QualityGateRow {
+  id: number
+  session_id: string
+  gate_name: QualityGate
+  status: QualityGateStatus
+  output: string
+  duration_ms: number | null
+  ran_at: string
+}
+
+export interface RecordQualityGateInput {
+  sessionId: string
+  gateName: QualityGate
+  status: QualityGateStatus
+  output: string
+  durationMs: number | null
+}
+
+export class QualityGateRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: RecordQualityGateInput): void {
+    this.db
+      .prepare(
+        `INSERT INTO quality_gate_runs (session_id, gate_name, status, output, duration_ms)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(input.sessionId, input.gateName, input.status, input.output, input.durationMs)
+  }
+
+  listForSession(sessionId: string): QualityGateRun[] {
+    const rows = this.db
+      .prepare<[string], QualityGateRow>(
+        'SELECT * FROM quality_gate_runs WHERE session_id = ? ORDER BY ran_at',
+      )
+      .all(sessionId)
+    return rows.map((row) =>
+      QualityGateRunSchema.parse({
+        id: String(row.id),
+        sessionId: row.session_id,
+        gateName: row.gate_name,
+        status: row.status,
+        output: row.output,
+        ranAt: row.ran_at,
+        durationMs: row.duration_ms ?? undefined,
+      }),
+    )
+  }
+}

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -1,29 +1,44 @@
 // Hono application setup. Routes return shapes defined in @maestro/api so the
 // dashboard always agrees with the conductor on types.
 //
-// Phase 0 routes are read-only stubs; Phase 1+ wires them to real data.
+// Phase 1: project + session lists return real data from SQLite. The
+// session-detail and session-log routes power the dashboard's "what
+// happened" view.
 
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { logger as honoLogger } from 'hono/logger'
 import { HTTPException } from 'hono/http-exception'
+import { existsSync } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
 import {
+  HealthResponseSchema,
   ListProjectsResponseSchema,
   ListSessionsResponseSchema,
-  HealthResponseSchema,
 } from '@maestro/api'
-import { isMaestroError } from '@maestro/shared'
+import {
+  SESSION_LOG_TAIL_LINES,
+  isMaestroError,
+} from '@maestro/shared'
+import type Database from 'better-sqlite3'
 import { logger } from './logger.js'
+import { ProjectRepository, QualityGateRepository, SessionRepository } from './repositories.js'
 
 export interface ServerDeps {
   /** Best-effort uptime baseline for the /health response. */
   startedAt: number
   /** Package version surfaced in /health. */
   version: string
+  /** SQLite handle. */
+  db: Database.Database
 }
 
 export function buildServer(deps: ServerDeps): Hono {
   const app = new Hono()
+  const projects = new ProjectRepository(deps.db)
+  const sessions = new SessionRepository(deps.db)
+  const gates = new QualityGateRepository(deps.db)
 
   app.use('*', honoLogger((msg) => logger.debug(msg)))
   app.use('/api/*', cors({ origin: '*' }))
@@ -33,9 +48,7 @@ export function buildServer(deps: ServerDeps): Hono {
     if (isMaestroError(err)) {
       logger.error({ err }, 'request failed with MaestroError')
       return c.json(
-        {
-          error: { code: err.code, message: err.message, context: err.context },
-        },
+        { error: { code: err.code, message: err.message, context: err.context } },
         500,
       )
     }
@@ -57,13 +70,59 @@ export function buildServer(deps: ServerDeps): Hono {
   })
 
   app.get('/api/projects', (c) => {
-    const body = ListProjectsResponseSchema.parse({ projects: [] })
+    const body = ListProjectsResponseSchema.parse({ projects: projects.list() })
     return c.json(body)
   })
 
+  app.get('/api/projects/:slug', (c) => {
+    const project = projects.findBySlug(c.req.param('slug'))
+    if (!project) {
+      return c.json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Unknown project' } }, 404)
+    }
+    return c.json({ project })
+  })
+
   app.get('/api/sessions', (c) => {
-    const body = ListSessionsResponseSchema.parse({ sessions: [], total: 0 })
+    const projectId = c.req.query('projectId')
+    const limit = parseInt(c.req.query('limit') ?? '50', 10)
+    const offset = parseInt(c.req.query('offset') ?? '0', 10)
+    const result = sessions.list({
+      projectId,
+      limit: Number.isFinite(limit) ? limit : 50,
+      offset: Number.isFinite(offset) ? offset : 0,
+    })
+    const body = ListSessionsResponseSchema.parse(result)
     return c.json(body)
+  })
+
+  app.get('/api/sessions/:id', (c) => {
+    const id = c.req.param('id')
+    const session = sessions.findById(id)
+    if (!session) {
+      return c.json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } }, 404)
+    }
+    return c.json({
+      session,
+      qualityGates: gates.listForSession(id),
+    })
+  })
+
+  app.get('/api/sessions/:id/log', async (c) => {
+    const id = c.req.param('id')
+    const session = sessions.findById(id)
+    if (!session) {
+      return c.json({ error: { code: 'SESSION_NOT_FOUND', message: 'Unknown session' } }, 404)
+    }
+    if (!session.logPath || !existsSync(session.logPath)) {
+      return c.json({ tail: '', truncated: false, available: false })
+    }
+    const tail = await readTail(session.logPath, SESSION_LOG_TAIL_LINES)
+    return c.json({
+      tail: tail.text,
+      truncated: tail.truncated,
+      available: true,
+      sizeBytes: tail.sizeBytes,
+    })
   })
 
   app.get('/api/prs', (c) => c.json({ pullRequests: [] }))
@@ -73,4 +132,47 @@ export function buildServer(deps: ServerDeps): Hono {
   )
 
   return app
+}
+
+interface TailResult {
+  text: string
+  truncated: boolean
+  sizeBytes: number
+}
+
+async function readTail(path: string, lines: number): Promise<TailResult> {
+  const info = await stat(path)
+  // Quick path for small files: just read it all.
+  if (info.size < 256 * 1024) {
+    return new Promise<TailResult>((resolve, reject) => {
+      const chunks: Buffer[] = []
+      const stream = createReadStream(path)
+      stream.on('data', (chunk: string | Buffer) => {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+      })
+      stream.on('error', reject)
+      stream.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf-8')
+        const split = text.split('\n')
+        if (split.length <= lines) {
+          resolve({ text, truncated: false, sizeBytes: info.size })
+        } else {
+          resolve({
+            text: split.slice(-lines).join('\n'),
+            truncated: true,
+            sizeBytes: info.size,
+          })
+        }
+      })
+    })
+  }
+  // Larger file: read just the trailing slice (last 256KB) and tail it.
+  const stream = createReadStream(path, { start: Math.max(0, info.size - 256 * 1024) })
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk as string) : (chunk as Buffer))
+  }
+  const text = Buffer.concat(chunks).toString('utf-8')
+  const split = text.split('\n').slice(-lines)
+  return { text: split.join('\n'), truncated: true, sizeBytes: info.size }
 }

--- a/packages/conductor/src/stack-detector.ts
+++ b/packages/conductor/src/stack-detector.ts
@@ -1,0 +1,128 @@
+// Project stack detection. Looks at well-known root files to figure out
+// which build/test/lint commands a managed project uses, then maps each
+// quality gate (test, lint, typecheck, build) to a concrete argv.
+//
+// Detection order matters — pnpm before npm before yarn before bun, because
+// the lockfile is the most reliable signal. Python and Rust stacks are
+// detected by their respective manifests.
+
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { ProjectStack, QualityGate, QualityGateCommand } from '@maestro/shared'
+
+interface NodePackageJson {
+  scripts?: Record<string, string>
+}
+
+export interface DetectedStack {
+  stack: ProjectStack
+  /** Lookup: gate → argv. Missing entry means the gate can't be run. */
+  gates: Partial<Record<QualityGate, QualityGateCommand>>
+}
+
+export async function detectStack(projectRoot: string): Promise<DetectedStack> {
+  // Node ecosystem — read package.json scripts to be smart about commands.
+  if (existsSync(join(projectRoot, 'package.json'))) {
+    const manager = detectNodePackageManager(projectRoot)
+    const pkg = await readPackageJson(projectRoot)
+    const gates = nodeGates(manager, pkg, projectRoot)
+    return { stack: manager, gates }
+  }
+
+  if (existsSync(join(projectRoot, 'pyproject.toml'))) {
+    return { stack: 'python-poetry', gates: pythonGates() }
+  }
+
+  if (
+    existsSync(join(projectRoot, 'requirements.txt')) ||
+    existsSync(join(projectRoot, 'setup.py'))
+  ) {
+    return { stack: 'python-pip', gates: pythonGates() }
+  }
+
+  if (existsSync(join(projectRoot, 'Cargo.toml'))) {
+    return { stack: 'rust-cargo', gates: rustGates() }
+  }
+
+  if (existsSync(join(projectRoot, 'go.mod'))) {
+    return { stack: 'go-mod', gates: goGates() }
+  }
+
+  return { stack: 'unknown', gates: {} }
+}
+
+type NodeManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
+
+function detectNodePackageManager(projectRoot: string): NodeManager {
+  if (existsSync(join(projectRoot, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(projectRoot, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(projectRoot, 'bun.lockb'))) return 'bun'
+  return 'npm'
+}
+
+async function readPackageJson(projectRoot: string): Promise<NodePackageJson> {
+  try {
+    const raw = await readFile(join(projectRoot, 'package.json'), 'utf-8')
+    return JSON.parse(raw) as NodePackageJson
+  } catch {
+    return {}
+  }
+}
+
+function nodeGates(
+  manager: NodeManager,
+  pkg: NodePackageJson,
+  projectRoot: string,
+): DetectedStack['gates'] {
+  const scripts = pkg.scripts ?? {}
+  const gates: DetectedStack['gates'] = {}
+  if (scripts['test']) gates['test'] = runScript(manager, 'test')
+  if (scripts['lint']) gates['lint'] = runScript(manager, 'lint')
+  if (scripts['typecheck']) gates['typecheck'] = runScript(manager, 'typecheck')
+  else if (scripts['tsc']) gates['typecheck'] = runScript(manager, 'tsc')
+  else if (existsSync(join(projectRoot, 'tsconfig.json'))) {
+    gates['typecheck'] = { command: 'npx', args: ['tsc', '--noEmit'] }
+  }
+  if (scripts['build']) gates['build'] = runScript(manager, 'build')
+  return gates
+}
+
+function runScript(manager: NodeManager, script: string): QualityGateCommand {
+  switch (manager) {
+    case 'pnpm':
+      return { command: 'pnpm', args: ['run', script] }
+    case 'yarn':
+      return { command: 'yarn', args: [script] }
+    case 'bun':
+      return { command: 'bun', args: ['run', script] }
+    default:
+      return { command: 'npm', args: ['run', script] }
+  }
+}
+
+function pythonGates(): DetectedStack['gates'] {
+  // Conservative defaults; real projects override via context.md (Phase 1
+  // we keep this simple).
+  return {
+    test: { command: 'pytest', args: [] },
+    typecheck: { command: 'mypy', args: ['.'] },
+  }
+}
+
+function rustGates(): DetectedStack['gates'] {
+  return {
+    test: { command: 'cargo', args: ['test'] },
+    typecheck: { command: 'cargo', args: ['check'] },
+    build: { command: 'cargo', args: ['build'] },
+    lint: { command: 'cargo', args: ['clippy', '--', '-D', 'warnings'] },
+  }
+}
+
+function goGates(): DetectedStack['gates'] {
+  return {
+    test: { command: 'go', args: ['test', './...'] },
+    build: { command: 'go', args: ['build', './...'] },
+    typecheck: { command: 'go', args: ['vet', './...'] },
+  }
+}

--- a/packages/conductor/src/state-manager.ts
+++ b/packages/conductor/src/state-manager.ts
@@ -1,51 +1,302 @@
-// .maestro/ file I/O. Reads state.md, context.md, journal entries, and parses
-// autonomy.json with Zod. Writes are locked per-project to prevent concurrent
-// session corruption. Phase 1 work (see PRODUCT_VISION.md).
+// .maestro/ file I/O for managed projects. Reads and writes state.md,
+// context.md, autonomy.json, and the journal directory, with Zod validation
+// at every boundary. File locks via proper-lockfile keep two writers out
+// of the directory at once.
 //
-// Stubs here so callers compile against the intended surface area.
+// IMPORTANT: the agent itself is responsible for editing .maestro/ during a
+// session (per PROMPT_DESIGN.md). Maestro reads state for prompt
+// construction and validates that the agent did its part on session exit;
+// it does NOT mutate state.md or write journal entries on the agent's
+// behalf except in `init`.
 
-import type { ProjectAutonomyConfig, ProjectState, JournalEntry } from '@maestro/shared'
-import { MaestroError } from '@maestro/shared'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import lockfile from 'proper-lockfile'
+import {
+  AutonomyFileSchema,
+  JournalEntrySchema,
+  MAESTRO_DIR_NAME,
+  MAESTRO_PATHS,
+  MaestroError,
+  ProjectStateSchema,
+  type JournalEntry,
+  type ProjectAutonomyConfig,
+  type ProjectState,
+} from '@maestro/shared'
 
-export interface StateManagerInput {
-  /** Absolute path to the working checkout of the project. */
-  projectRoot: string
+// ─── Paths ───────────────────────────────────────────────────────────
+
+export interface ProjectPaths {
+  root: string
+  maestroDir: string
+  state: string
+  context: string
+  decisions: string
+  autonomy: string
+  journalDir: string
 }
 
-export async function readState(_input: StateManagerInput): Promise<ProjectState> {
-  throw notImplemented('readState')
+export function projectPaths(projectRoot: string): ProjectPaths {
+  const maestroDir = join(projectRoot, MAESTRO_DIR_NAME)
+  return {
+    root: projectRoot,
+    maestroDir,
+    state: join(maestroDir, MAESTRO_PATHS.state),
+    context: join(maestroDir, MAESTRO_PATHS.context),
+    decisions: join(maestroDir, MAESTRO_PATHS.decisions),
+    autonomy: join(maestroDir, MAESTRO_PATHS.autonomy),
+    journalDir: join(maestroDir, MAESTRO_PATHS.journal),
+  }
 }
 
-export async function writeState(
-  _input: StateManagerInput & { state: ProjectState },
-): Promise<void> {
-  throw notImplemented('writeState')
+// ─── Validators ──────────────────────────────────────────────────────
+
+export interface ValidatedMaestroDir {
+  state: ProjectState
+  context: string
+  autonomy: ProjectAutonomyConfig
 }
 
-export async function readContext(_input: StateManagerInput): Promise<string> {
-  throw notImplemented('readContext')
+/**
+ * Read state.md, context.md, autonomy.json from disk and parse them
+ * through their Zod schemas. Aborts with a structured MaestroError if any
+ * file is missing or malformed — the developer must repair `.maestro/`
+ * before sessions can run.
+ */
+export async function readMaestroDir(projectRoot: string): Promise<ValidatedMaestroDir> {
+  const paths = projectPaths(projectRoot)
+
+  if (!existsSync(paths.maestroDir)) {
+    throw new MaestroError('CONTEXT_FILE_MISSING', {
+      message: `${MAESTRO_DIR_NAME}/ does not exist in ${projectRoot}`,
+      context: { projectRoot },
+    })
+  }
+
+  const [stateBody, contextBody, autonomyBody] = await Promise.all([
+    safeRead(paths.state, 'state.md'),
+    safeRead(paths.context, 'context.md'),
+    safeRead(paths.autonomy, 'autonomy.json'),
+  ])
+
+  const state = ProjectStateSchema.parse({
+    raw: stateBody,
+    path: relPath(paths.root, paths.state),
+  })
+
+  let autonomy: ProjectAutonomyConfig
+  try {
+    autonomy = AutonomyFileSchema.parse(JSON.parse(autonomyBody))
+  } catch (err) {
+    throw new MaestroError('AUTONOMY_CONFIG_INVALID', {
+      message: 'autonomy.json failed validation',
+      cause: err,
+      context: { path: paths.autonomy },
+    })
+  }
+
+  return { state, context: contextBody, autonomy }
 }
 
-export async function readAutonomy(
-  _input: StateManagerInput,
-): Promise<ProjectAutonomyConfig> {
-  throw notImplemented('readAutonomy')
+async function safeRead(path: string, kind: string): Promise<string> {
+  try {
+    return await readFile(path, 'utf-8')
+  } catch (err) {
+    throw new MaestroError('CONTEXT_FILE_MISSING', {
+      message: `Failed to read ${kind} at ${path}`,
+      cause: err,
+      context: { path, kind },
+    })
+  }
+}
+
+function relPath(base: string, target: string): string {
+  if (target.startsWith(base)) return target.slice(base.length).replace(/^\/+/, '')
+  return target
+}
+
+// ─── Journal ─────────────────────────────────────────────────────────
+
+const JOURNAL_FILENAME_RE = /^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.md$/
+
+export async function listJournalEntries(projectRoot: string): Promise<JournalEntry[]> {
+  const paths = projectPaths(projectRoot)
+  if (!existsSync(paths.journalDir)) return []
+
+  const filenames = (await readdir(paths.journalDir))
+    .filter((f) => JOURNAL_FILENAME_RE.test(f))
+    .sort() // lexicographic == chronological for ISO-ish names
+
+  const entries: JournalEntry[] = []
+  for (const filename of filenames) {
+    const body = await readFile(join(paths.journalDir, filename), 'utf-8')
+    const timestamp = filenameToIso(filename)
+    entries.push(
+      JournalEntrySchema.parse({
+        filename,
+        sessionId: null,
+        timestamp,
+        body,
+      }),
+    )
+  }
+  return entries
 }
 
 export async function listRecentJournal(
-  _input: StateManagerInput & { limit: number },
+  projectRoot: string,
+  limit: number,
 ): Promise<JournalEntry[]> {
-  throw notImplemented('listRecentJournal')
+  const all = await listJournalEntries(projectRoot)
+  return all.slice(-limit)
 }
 
-export async function appendJournal(
-  _input: StateManagerInput & { entry: JournalEntry },
-): Promise<void> {
-  throw notImplemented('appendJournal')
+function filenameToIso(filename: string): string {
+  // 2026-04-15-08-00.md → 2026-04-15T08:00:00.000Z
+  const match = /^(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})\.md$/.exec(filename)
+  if (!match) {
+    throw new MaestroError('STATE_PARSE_FAILED', {
+      message: `Bad journal filename: ${filename}`,
+      context: { filename },
+    })
+  }
+  const [, y, m, d, hh, mm] = match
+  return `${y}-${m}-${d}T${hh}:${mm}:00.000Z`
 }
 
-function notImplemented(name: string): MaestroError {
-  return new MaestroError('INTERNAL_ERROR', {
-    message: `state-manager.${name} is Phase 1 work. See PRODUCT_VISION.md.`,
+// ─── Init flow ───────────────────────────────────────────────────────
+
+export interface InitMaestroDirInput {
+  projectRoot: string
+  state: string
+  context: string
+  autonomy: ProjectAutonomyConfig
+  /** Optional decisions.md seed. */
+  decisions?: string
+}
+
+/**
+ * Create a fresh `.maestro/` skeleton. Used by `maestro init`. Refuses to
+ * overwrite an existing directory.
+ */
+export async function initMaestroDir(input: InitMaestroDirInput): Promise<void> {
+  const paths = projectPaths(input.projectRoot)
+  if (existsSync(paths.maestroDir)) {
+    throw new MaestroError('STATE_WRITE_FAILED', {
+      message: `${MAESTRO_DIR_NAME}/ already exists in ${input.projectRoot}`,
+      context: { path: paths.maestroDir },
+    })
+  }
+  await mkdir(paths.maestroDir, { recursive: true })
+  await mkdir(paths.journalDir, { recursive: true })
+  await Promise.all([
+    writeFile(paths.state, ensureTrailingNewline(input.state), 'utf-8'),
+    writeFile(paths.context, ensureTrailingNewline(input.context), 'utf-8'),
+    writeFile(
+      paths.decisions,
+      ensureTrailingNewline(input.decisions ?? defaultDecisions()),
+      'utf-8',
+    ),
+    writeFile(paths.autonomy, JSON.stringify(input.autonomy, null, 2) + '\n', 'utf-8'),
+    writeFile(join(paths.journalDir, '.gitkeep'), '', 'utf-8'),
+  ])
+
+  // Validate what we just wrote — same path the worker takes.
+  await readMaestroDir(input.projectRoot)
+}
+
+function defaultDecisions(): string {
+  return [
+    '# Project Decisions',
+    '',
+    'Track significant choices and the reasoning behind them. The agent reads',
+    'this every session and respects past decisions unless state.md',
+    'explicitly overrides one.',
+    '',
+  ].join('\n')
+}
+
+function ensureTrailingNewline(s: string): string {
+  return s.endsWith('\n') ? s : s + '\n'
+}
+
+// ─── Validation of agent output ──────────────────────────────────────
+
+export interface MaestroDirAgentOutputCheck {
+  stateUpdated: boolean
+  journalAppended: boolean
+  newJournalFile: string | null
+}
+
+/**
+ * After a session, verify the agent updated state.md and dropped a new
+ * journal entry. Compares against a snapshot taken at session start.
+ */
+export async function verifyAgentTouchedMaestroDir(
+  projectRoot: string,
+  before: { stateMTimeMs: number; journalFilenames: string[] },
+): Promise<MaestroDirAgentOutputCheck> {
+  const paths = projectPaths(projectRoot)
+  const stateStat = await stat(paths.state)
+  const stateUpdated = stateStat.mtimeMs > before.stateMTimeMs
+  const after = (await readdir(paths.journalDir).catch(() => [])).filter((f) => JOURNAL_FILENAME_RE.test(f))
+  const newFiles = after.filter((f) => !before.journalFilenames.includes(f))
+  return {
+    stateUpdated,
+    journalAppended: newFiles.length > 0,
+    newJournalFile: newFiles[0] ?? null,
+  }
+}
+
+export async function snapshotMaestroDir(projectRoot: string): Promise<{
+  stateMTimeMs: number
+  journalFilenames: string[]
+}> {
+  const paths = projectPaths(projectRoot)
+  const stateStat = await stat(paths.state)
+  const journal = (await readdir(paths.journalDir).catch(() => [])).filter((f) => JOURNAL_FILENAME_RE.test(f))
+  return { stateMTimeMs: stateStat.mtimeMs, journalFilenames: journal }
+}
+
+// ─── Locking ─────────────────────────────────────────────────────────
+
+/**
+ * Run `fn` while holding a filesystem lock on the project's `.maestro/`
+ * directory. Uses proper-lockfile so two processes cannot stomp on the
+ * directory at once.
+ */
+export async function withMaestroDirLock<T>(
+  projectRoot: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const paths = projectPaths(projectRoot)
+  if (!existsSync(paths.maestroDir)) {
+    throw new MaestroError('CONTEXT_FILE_MISSING', {
+      message: `${MAESTRO_DIR_NAME}/ does not exist`,
+      context: { path: paths.maestroDir },
+    })
+  }
+  const release = await lockfile.lock(paths.maestroDir, {
+    retries: { retries: 5, factor: 1.5, minTimeout: 100, maxTimeout: 2000 },
+    stale: 5 * 60 * 1000,
   })
+  try {
+    return await fn()
+  } finally {
+    await release()
+  }
+}
+
+// Walk up from cwd looking for a directory containing `.maestro/`. Used by
+// the CLI when `<project-path>` isn't passed explicitly.
+export async function findProjectRootFromCwd(start = process.cwd()): Promise<string | null> {
+  let dir = start
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, MAESTRO_DIR_NAME))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+  return null
 }

--- a/packages/conductor/src/test/fixtures/golden-context.md
+++ b/packages/conductor/src/test/fixtures/golden-context.md
@@ -1,0 +1,22 @@
+# Project Context — testproject
+
+## Stack
+
+Node.js 22 + TypeScript strict. Vite for the dashboard. Hono for the API.
+
+### Scripts
+
+- `test`: `vitest run`
+- `lint`: `eslint .`
+- `typecheck`: `tsc --noEmit`
+
+## Conventions
+
+- Conventional commits (feat:, fix:, refactor:)
+- Single quotes, no semis, trailing commas
+- One feature per PR
+
+## Project-specific NEVER list
+
+- Never modify the migration ordering in db/migrations
+- Never bump @maestro/* packages without a version bump in DECISIONS.md

--- a/packages/conductor/src/test/fixtures/golden-journal-1.md
+++ b/packages/conductor/src/test/fixtures/golden-journal-1.md
@@ -1,0 +1,25 @@
+# Session 2026-04-25T08:00:00.000Z
+
+## Goal
+Land the polling-based status indicator on the dashboard.
+
+## What I Did
+Added a `useApi` hook calling `/api/health` every 15s and surfaced a pill in the header.
+
+## What Worked
+Keeping the hook tiny made the change easy to review.
+
+## What Didn't
+Initial implementation re-fetched on every render — fixed with useEffect cleanup.
+
+## Quality Gates
+test, lint, typecheck — all passed.
+
+## State Update
+Cleared the polling task; queued the websocket follow-up.
+
+## For Next Session
+The polling implementation is fine for now but burns dashboard bandwidth.
+
+## Cost
+~3.2k input / 1.1k output tokens.

--- a/packages/conductor/src/test/fixtures/golden-journal-2.md
+++ b/packages/conductor/src/test/fixtures/golden-journal-2.md
@@ -1,0 +1,25 @@
+# Session 2026-04-26T08:00:00.000Z
+
+## Goal
+Add error states to the polling indicator.
+
+## What I Did
+Detect 4xx/5xx + network failures, show a "conductor offline" pill instead.
+
+## What Worked
+The existing pill component already supported variant classes.
+
+## What Didn't
+Got distracted writing tests for the mocked fetch; deferred to a separate PR.
+
+## Quality Gates
+test, lint, typecheck — all passed.
+
+## State Update
+Removed "error states" from Next Concrete Tasks; nothing new added.
+
+## For Next Session
+Polling error handling complete. Move to websockets next.
+
+## Cost
+~2.8k input / 0.9k output tokens.

--- a/packages/conductor/src/test/fixtures/golden-prompt.txt
+++ b/packages/conductor/src/test/fixtures/golden-prompt.txt
@@ -1,0 +1,209 @@
+You are an autonomous developer working on the project: testproject.
+
+Your time budget: 45 minutes. At 40 minutes, begin
+wrapping up cleanly. At 45 minutes, your process will be killed.
+
+You are working in a fresh checkout of the main branch. The git identity is
+already configured to Aaryan Sinha. All commits will appear under the
+developer's name.
+
+== PROJECT CONTEXT ==
+
+# Project Context — testproject
+
+## Stack
+
+Node.js 22 + TypeScript strict. Vite for the dashboard. Hono for the API.
+
+### Scripts
+
+- `test`: `vitest run`
+- `lint`: `eslint .`
+- `typecheck`: `tsc --noEmit`
+
+## Conventions
+
+- Conventional commits (feat:, fix:, refactor:)
+- Single quotes, no semis, trailing commas
+- One feature per PR
+
+## Project-specific NEVER list
+
+- Never modify the migration ordering in db/migrations
+- Never bump @maestro/* packages without a version bump in DECISIONS.md
+
+== CURRENT STATE ==
+
+# Current State
+
+## Focus
+Build the websocket-based agent feed for the dashboard. The HTTP polling
+prototype is in main; we need an event stream.
+
+## Next Concrete Tasks
+- [ ] Wire the conductor to broadcast session events over WS at /events
+- [ ] Add a useEvents() hook on the dashboard
+- [ ] Show live session status without page refresh
+
+## Blockers
+
+_(none)_
+
+## Recent Context
+
+Polling-based status indicator landed last week. It works but creates
+unnecessary load every 15s for every open dashboard tab.
+
+## Notes
+
+Prefer ws over socket.io — single dashboard user, no need for the abstraction.
+
+== RECENT JOURNAL (last 3 sessions) ==
+
+### 2026-04-25-08-00.md
+
+# Session 2026-04-25T08:00:00.000Z
+
+## Goal
+Land the polling-based status indicator on the dashboard.
+
+## What I Did
+Added a `useApi` hook calling `/api/health` every 15s and surfaced a pill in the header.
+
+## What Worked
+Keeping the hook tiny made the change easy to review.
+
+## What Didn't
+Initial implementation re-fetched on every render — fixed with useEffect cleanup.
+
+## Quality Gates
+test, lint, typecheck — all passed.
+
+## State Update
+Cleared the polling task; queued the websocket follow-up.
+
+## For Next Session
+The polling implementation is fine for now but burns dashboard bandwidth.
+
+## Cost
+~3.2k input / 1.1k output tokens.
+
+### 2026-04-26-08-00.md
+
+# Session 2026-04-26T08:00:00.000Z
+
+## Goal
+Add error states to the polling indicator.
+
+## What I Did
+Detect 4xx/5xx + network failures, show a "conductor offline" pill instead.
+
+## What Worked
+The existing pill component already supported variant classes.
+
+## What Didn't
+Got distracted writing tests for the mocked fetch; deferred to a separate PR.
+
+## Quality Gates
+test, lint, typecheck — all passed.
+
+## State Update
+Removed "error states" from Next Concrete Tasks; nothing new added.
+
+## For Next Session
+Polling error handling complete. Move to websockets next.
+
+## Cost
+~2.8k input / 0.9k output tokens.
+
+== YOUR TASK ==
+
+Wire the conductor to broadcast session events over WS at /events
+
+== RULES ==
+
+1. Make focused progress. Pick ONE task from the list above. Don't try to do
+   multiple things in one session.
+
+2. If the task is unclear or doesn't make sense given the current code, DO NOT
+   guess. Write your concerns to the journal and stop. Empty sessions are fine.
+
+3. Quality gates will run after you commit:
+   - `test`
+   - `lint`
+   - `typecheck`
+   Your code must pass all of them. Run them yourself before committing.
+
+4. Follow the project's existing conventions:
+   - Code style (read context.md)
+   - Commit message format (read context.md)
+   - Testing patterns (read context.md)
+   - Don't introduce new dependencies without good reason
+
+5. Before finishing, you MUST:
+   a. Update .maestro/state.md to reflect what was done and what's next
+   b. Append a session summary to .maestro/journal/{timestamp}.md
+   c. Commit all changes (including .maestro/ updates) on a feature branch
+   d. The feature branch name should be: maestro/testproject/{short-description}
+
+6. Things you must NEVER touch without explicit state.md instruction:
+   - Authentication / authorization code
+   - Payment processing
+   - Production database migrations
+   - CI/CD configuration
+   - Environment variable handling
+   - Cryptography or security primitives
+
+   - the WebSocket auth flow
+
+7. If you discover something important during the session that future sessions
+   need to know, add it to context.md (the long-lived context) — but only for
+   genuinely durable information, not session-specific notes.
+
+== JOURNAL ENTRY FORMAT ==
+
+When you append to the journal, use this format:
+
+```
+# Session {ISO timestamp}
+
+## Goal
+{what you set out to do}
+
+## What I Did
+{narrative of the work, including reasoning}
+
+## What Worked
+{techniques or approaches that worked well}
+
+## What Didn't
+{dead ends, mistakes corrected, things that didn't work}
+
+## Quality Gates
+{which gates ran, results}
+
+## State Update
+{what you changed in state.md and why}
+
+## For Next Session
+{important context for the next agent that runs}
+
+## Cost
+{tokens used if available}
+```
+
+== STATE.MD UPDATE FORMAT ==
+
+After your work, state.md should reflect:
+
+- The "Focus" section may stay the same or change slightly
+- The "Next Concrete Tasks" should have your task removed and possibly new
+  tasks added based on what you discovered
+- The "Blockers" section should be updated if you hit any
+- The "Recent Context" section should be 2-3 sentences about what just happened
+
+== BEGIN SESSION ==
+
+Start by acknowledging your task. Then proceed.
+
+[prompt-version: 1.0.0]

--- a/packages/conductor/src/test/fixtures/golden-state.md
+++ b/packages/conductor/src/test/fixtures/golden-state.md
@@ -1,0 +1,23 @@
+# Current State
+
+## Focus
+Build the websocket-based agent feed for the dashboard. The HTTP polling
+prototype is in main; we need an event stream.
+
+## Next Concrete Tasks
+- [ ] Wire the conductor to broadcast session events over WS at /events
+- [ ] Add a useEvents() hook on the dashboard
+- [ ] Show live session status without page refresh
+
+## Blockers
+
+_(none)_
+
+## Recent Context
+
+Polling-based status indicator landed last week. It works but creates
+unnecessary load every 15s for every open dashboard tab.
+
+## Notes
+
+Prefer ws over socket.io — single dashboard user, no need for the abstraction.

--- a/packages/conductor/src/test/mock-claude.mjs
+++ b/packages/conductor/src/test/mock-claude.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Mock `claude` binary for tests. The real Claude Code CLI is heavy and
+// non-deterministic; here we simulate exactly the side effects a session
+// would have:
+//   - apply a fixture diff in cwd
+//   - update .maestro/state.md
+//   - append a journal entry
+//   - make a git commit on a feature branch
+//   - emit a stream-json `result` line so the runner can parse usage
+//
+// Driven by env:
+//   MAESTRO_MOCK_FIXTURE  → path to JSON file describing actions
+//   MAESTRO_MOCK_INLINE   → JSON string (overrides _FIXTURE)
+//
+// Fixture shape:
+//   {
+//     "exitCode": 0,
+//     "delayMs": 0,
+//     "files": { "path/in/cwd.txt": "contents" },
+//     "branch": "maestro/<slug>/<short>",
+//     "commitMessage": "subject\n\nbody",
+//     "stateBody": "new state.md body",
+//     "journalFilename": "2026-04-15-08-00.md",
+//     "journalBody": "...",
+//     "result": { "model": "...", "usage": { "input_tokens": ..., ... } },
+//     "stdoutPrelude": "...",
+//     "stderrPrelude": "..."
+//   }
+
+import { execSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+function loadFixture() {
+  if (process.env.MAESTRO_MOCK_INLINE) {
+    return JSON.parse(process.env.MAESTRO_MOCK_INLINE)
+  }
+  if (process.env.MAESTRO_MOCK_FIXTURE) {
+    return JSON.parse(readFileSync(process.env.MAESTRO_MOCK_FIXTURE, 'utf-8'))
+  }
+  return {}
+}
+
+function git(cwd, ...args) {
+  return execSync(`git ${args.map((a) => `"${a.replace(/"/g, '\\"')}"`).join(' ')}`, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+    .toString()
+    .trim()
+}
+
+function writeFile(cwd, relPath, content) {
+  const full = join(cwd, relPath)
+  mkdirSync(dirname(full), { recursive: true })
+  writeFileSync(full, content)
+}
+
+async function main() {
+  const fixture = loadFixture()
+  const cwd = process.cwd()
+
+  if (fixture.stdoutPrelude) process.stdout.write(fixture.stdoutPrelude)
+  if (fixture.stderrPrelude) process.stderr.write(fixture.stderrPrelude)
+
+  if (fixture.delayMs) {
+    await new Promise((resolve) => setTimeout(resolve, fixture.delayMs))
+  }
+
+  // 1. apply file changes
+  if (fixture.files) {
+    for (const [path, content] of Object.entries(fixture.files)) {
+      writeFile(cwd, path, content)
+    }
+  }
+
+  // 2. update state.md
+  if (typeof fixture.stateBody === 'string') {
+    writeFile(cwd, '.maestro/state.md', fixture.stateBody)
+  }
+
+  // 3. append journal entry
+  if (fixture.journalFilename && typeof fixture.journalBody === 'string') {
+    writeFile(cwd, `.maestro/journal/${fixture.journalFilename}`, fixture.journalBody)
+  }
+
+  // 4. branch + commit
+  if (fixture.branch || fixture.commitMessage) {
+    const branchName = fixture.branch ?? `mock-claude/${Date.now()}`
+    try {
+      git(cwd, 'checkout', '-b', branchName)
+    } catch {
+      // branch may already exist if the test reuses a working dir; switch
+      git(cwd, 'checkout', branchName)
+    }
+    git(cwd, 'add', '-A')
+    const status = git(cwd, 'status', '--porcelain')
+    if (status.length > 0) {
+      const message = fixture.commitMessage ?? 'mock-claude commit'
+      git(cwd, 'commit', '-m', message)
+    }
+  }
+
+  // 5. stream-json result line
+  const resultLine = {
+    type: 'result',
+    session_id: 'mock-session',
+    model: fixture.result?.model ?? 'claude-opus-4-7-20250219',
+    usage: fixture.result?.usage ?? {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+  }
+  process.stdout.write(JSON.stringify(resultLine) + '\n')
+
+  // Read and discard stdin so the runner's input pipe doesn't block.
+  // Don't actually require it — `process.stdin` may be already closed.
+  if (process.stdin.readable) {
+    try {
+      let _bytes = 0
+      for await (const chunk of process.stdin) _bytes += chunk.length
+      void _bytes
+    } catch {
+      /* ignore */
+    }
+  }
+
+  process.exit(fixture.exitCode ?? 0)
+}
+
+main().catch((err) => {
+  process.stderr.write(`mock-claude: ${err}\n`)
+  process.exit(1)
+})
+
+// macOS may emit a deprecation about closing stdin if we exit fast.
+process.on('SIGTERM', () => process.exit(0))

--- a/packages/conductor/src/test/prompt.test.ts
+++ b/packages/conductor/src/test/prompt.test.ts
@@ -1,0 +1,84 @@
+// Golden-file test for buildSessionPrompt. The prompt template is the
+// most sensitive piece of code in the system — silent drift here directly
+// degrades agent behaviour. This test pins the exact bytes produced for a
+// representative input.
+//
+// To regenerate the golden file after an intentional template change:
+//   UPDATE_GOLDENS=1 pnpm --filter @maestro/conductor test prompt
+// Then re-read the file and confirm the diff is what you expected.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { buildSessionPrompt } from '@maestro/shared'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const FIXTURES = join(here, 'fixtures')
+
+describe('buildSessionPrompt', () => {
+  it('produces stable output for a representative project (golden file)', () => {
+    const state = readFileSync(join(FIXTURES, 'golden-state.md'), 'utf-8')
+    const context = readFileSync(join(FIXTURES, 'golden-context.md'), 'utf-8')
+    const j1 = readFileSync(join(FIXTURES, 'golden-journal-1.md'), 'utf-8')
+    const j2 = readFileSync(join(FIXTURES, 'golden-journal-2.md'), 'utf-8')
+
+    const prompt = buildSessionPrompt({
+      projectName: 'testproject',
+      projectSlug: 'testproject',
+      timeBudgetSeconds: 45 * 60,
+      developerName: 'Aaryan Sinha',
+      context,
+      state,
+      recentJournal: [
+        { filename: '2026-04-25-08-00.md', body: j1 },
+        { filename: '2026-04-26-08-00.md', body: j2 },
+      ],
+      task: 'Wire the conductor to broadcast session events over WS at /events',
+      qualityGates: ['test', 'lint', 'typecheck'],
+      projectSpecificNeverTouch: ['the WebSocket auth flow'],
+    })
+
+    const goldenPath = join(FIXTURES, 'golden-prompt.txt')
+
+    if (process.env['UPDATE_GOLDENS']) {
+      writeFileSync(goldenPath, prompt, 'utf-8')
+    }
+
+    const golden = readFileSync(goldenPath, 'utf-8')
+    expect(prompt).toBe(golden)
+  })
+
+  it('includes the FIRST SESSION preamble when no journal entries exist', () => {
+    const prompt = buildSessionPrompt({
+      projectName: 'fresh',
+      projectSlug: 'fresh',
+      timeBudgetSeconds: 1800,
+      developerName: 'Aaryan Sinha',
+      context: 'context',
+      state: 'state',
+      recentJournal: [],
+      task: 'orient',
+      qualityGates: [],
+      isFirstSession: true,
+    })
+    expect(prompt).toContain('FIRST SESSION')
+  })
+
+  it('includes the LONG PAUSE preamble after 14+ days', () => {
+    const prompt = buildSessionPrompt({
+      projectName: 'stale',
+      projectSlug: 'stale',
+      timeBudgetSeconds: 1800,
+      developerName: 'Aaryan Sinha',
+      context: 'context',
+      state: 'state',
+      recentJournal: [],
+      task: 'catch up',
+      qualityGates: [],
+      daysSinceLastSession: 30,
+    })
+    expect(prompt).toContain('LONG PAUSE')
+    expect(prompt).toContain('30 days')
+  })
+})

--- a/packages/conductor/src/test/worker.test.ts
+++ b/packages/conductor/src/test/worker.test.ts
@@ -1,0 +1,301 @@
+// End-to-end worker integration tests using a local git "remote" + the
+// mock-claude harness. No real claude, no real GitHub, no network.
+//
+// Each test sets up:
+//   - a tmp dir
+//   - a bare git repo acting as the GitHub "remote"
+//   - a fixture working clone with .maestro/ populated, pushed to that remote
+//   - a SQLite db (file-backed), a project row, and an InMemoryGitHubClient
+// then calls runSession() with a mock-claude fixture that simulates the
+// agent's side effects.
+
+import { execSync } from 'node:child_process'
+import { mkdtemp, rm, writeFile, mkdir, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { openDatabase, type DbHandle } from '../db.js'
+import { ProjectRepository } from '../repositories.js'
+import { runSession } from '../worker.js'
+import type { Config } from '../config.js'
+import type { ProjectAutonomyConfig } from '@maestro/shared'
+import { DEFAULT_AUTONOMY_CONFIG } from '@maestro/shared'
+import type { GitHubClient, RepoCoords } from '../pr-manager.js'
+import type { CreatePullRequestInput, AddLabelsInput } from '../pr-manager.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const MOCK_CLAUDE = join(here, 'mock-claude.mjs')
+
+interface Harness {
+  root: string
+  remoteDir: string
+  fixtureDir: string
+  dataDir: string
+  db: DbHandle
+  config: Config
+  projectId: string
+  slug: string
+}
+
+const TEST_AUTONOMY: ProjectAutonomyConfig = {
+  ...DEFAULT_AUTONOMY_CONFIG,
+  // 5-minute budget — long enough that the mock's instant exit doesn't race
+  // the wrap-up signal, short enough that a hung process surfaces quickly.
+  timeBudget: 300,
+  // Skip lint to keep stack detection fast; we'll add a typecheck stub.
+  qualityGates: ['test', 'typecheck'],
+  branches: { base: 'main', prefix: 'maestro/' },
+}
+
+async function gitInit(dir: string, opts: { bare?: boolean } = {}): Promise<void> {
+  const args = opts.bare ? ['git', 'init', '--bare', '-b', 'main'] : ['git', 'init', '-b', 'main']
+  execSync(args.join(' '), { cwd: dir, stdio: 'pipe' })
+  if (!opts.bare) {
+    execSync('git config user.email tester@example.com', { cwd: dir })
+    execSync('git config user.name "Tester"', { cwd: dir })
+  }
+}
+
+async function setupHarness(scenario: 'all-good' | 'failing-gate'): Promise<Harness> {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-test-'))
+  const remoteDir = join(root, 'remote.git')
+  const fixtureDir = join(root, 'fixture')
+  const dataDir = join(root, 'data')
+
+  await mkdir(remoteDir, { recursive: true })
+  await mkdir(fixtureDir, { recursive: true })
+  await mkdir(dataDir, { recursive: true })
+
+  await gitInit(remoteDir, { bare: true })
+  await gitInit(fixtureDir)
+
+  // package.json for stack detection — provides scripts to run as "gates".
+  const testScript = scenario === 'all-good' ? 'exit 0' : 'exit 0' // both scenarios let test pass
+  const typecheckScript = scenario === 'all-good' ? 'exit 0' : 'exit 1'
+  await writeFile(
+    join(fixtureDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'fixture-project',
+        version: '0.0.0',
+        private: true,
+        scripts: {
+          test: testScript,
+          typecheck: typecheckScript,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  // .maestro/ skeleton
+  await mkdir(join(fixtureDir, '.maestro/journal'), { recursive: true })
+  await writeFile(
+    join(fixtureDir, '.maestro/state.md'),
+    '# Current State\n\n## Focus\nTesting harness.\n\n## Next Concrete Tasks\n- [ ] Add a comment to the README\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nNew project.\n\n## Notes\n\n',
+  )
+  await writeFile(
+    join(fixtureDir, '.maestro/context.md'),
+    '# Project Context — fixture-project\n\n## Stack\n\nNode.\n',
+  )
+  await writeFile(
+    join(fixtureDir, '.maestro/autonomy.json'),
+    JSON.stringify(TEST_AUTONOMY, null, 2),
+  )
+  await writeFile(join(fixtureDir, '.maestro/journal/.gitkeep'), '')
+  await writeFile(join(fixtureDir, 'README.md'), '# Fixture\n')
+
+  execSync('git add -A', { cwd: fixtureDir })
+  execSync('git -c user.email=t@test -c user.name=Tester commit -m "init fixture"', {
+    cwd: fixtureDir,
+  })
+  execSync(`git remote add origin ${remoteDir}`, { cwd: fixtureDir })
+  execSync('git push -u origin main', { cwd: fixtureDir, stdio: 'pipe' })
+
+  // Open the conductor SQLite at <dataDir>/maestro.db
+  const db = openDatabase({ dataDir })
+  const projects = new ProjectRepository(db.db)
+  const slug = `fixture-${randomUUID().slice(0, 8)}`
+  const projectId = randomUUID()
+  projects.insert({
+    id: projectId,
+    slug,
+    repoUrl: `file://${remoteDir}`,
+    autonomyConfig: TEST_AUTONOMY,
+  })
+
+  const config: Config = {
+    port: 3001,
+    dataDir,
+    developerName: 'Tester',
+    developerGithubUsername: 'tester',
+    nodeEnv: 'test',
+    developerEmail: 'tester@example.com',
+  }
+
+  return { root, remoteDir, fixtureDir, dataDir, db, config, projectId, slug }
+}
+
+interface FakeGitHub extends GitHubClient {
+  created: CreatePullRequestInput[]
+  labelsAdded: AddLabelsInput[]
+}
+
+function fakeGitHub(): FakeGitHub {
+  const created: CreatePullRequestInput[] = []
+  const labelsAdded: AddLabelsInput[] = []
+  return {
+    created,
+    labelsAdded,
+    async createPullRequest(req) {
+      created.push(req)
+      return {
+        number: 42,
+        url: `https://example.test/pr/42`,
+        title: req.title,
+        body: req.body,
+        status: req.draft ? 'draft' : 'open',
+        branchName: req.branchName,
+        baseBranch: req.baseBranch,
+        createdAt: new Date().toISOString(),
+        mergedAt: null,
+        sessionId: null,
+      }
+    },
+    async addLabels(req) {
+      labelsAdded.push(req)
+    },
+    async listOpenPullRequests(_repo: RepoCoords) {
+      return []
+    },
+    async verifyScopes() {
+      /* no-op */
+    },
+  }
+}
+
+let harness: Harness | null = null
+
+afterEach(async () => {
+  if (harness) {
+    harness.db.close()
+    await rm(harness.root, { recursive: true, force: true })
+    harness = null
+  }
+})
+
+describe('runSession (integration)', () => {
+  beforeEach(() => {
+    // No-op: each test calls setupHarness in its own context.
+  })
+
+  it('happy path: agent commits, gates pass, PR opens', async () => {
+    harness = await setupHarness('all-good')
+    const { db, config, slug } = harness
+    const projects = new ProjectRepository(db.db)
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    const gh = fakeGitHub()
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({
+      files: { 'README.md': '# Fixture\n\nTouched by mock.\n' },
+      branch: `maestro/${slug}/touch-readme`,
+      commitMessage: 'chore: touch README',
+      stateBody:
+        '# Current State\n\n## Focus\nTesting harness.\n\n## Next Concrete Tasks\n- [ ] Next thing\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nMock touched README.\n\n## Notes\n\n',
+      journalFilename: '2026-04-28-09-00.md',
+      journalBody:
+        '# Session 2026-04-28T09:00:00.000Z\n\n## Goal\nTouch README\n\n## What I Did\nAdded a line.\n',
+      result: { usage: { input_tokens: 1234, output_tokens: 567 } },
+    })
+
+    const result = await runSession({
+      db: db.db,
+      config,
+      project,
+      claudeBin: MOCK_CLAUDE,
+      githubClient: gh,
+      skipClaudeProbe: true,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.branchName).toBe(`maestro/${slug}/touch-readme`)
+    expect(result.qualityGates.length).toBeGreaterThan(0)
+    expect(result.prNumber).toBe(42)
+    expect(gh.created).toHaveLength(1)
+    expect(gh.created[0]?.branchName).toBe(`maestro/${slug}/touch-readme`)
+    expect(gh.created[0]?.baseBranch).toBe('main')
+
+    // .maestro/ updates land in the working dir
+    const wdState = await readFile(
+      join(harness.dataDir, 'work', slug, '.maestro/state.md'),
+      'utf-8',
+    )
+    expect(wdState).toContain('Mock touched README')
+  }, 60_000)
+
+  it('failed-gate path: agent commits, gate fails, no PR, fixup turn runs', async () => {
+    harness = await setupHarness('failing-gate')
+    const { db, config, slug } = harness
+    const projects = new ProjectRepository(db.db)
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    const gh = fakeGitHub()
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({
+      files: { 'README.md': '# Fixture\n\nFailing path.\n' },
+      branch: `maestro/${slug}/breakage`,
+      commitMessage: 'chore: introduce break',
+      stateBody:
+        '# Current State\n\n## Focus\n.\n\n## Next Concrete Tasks\n- [ ] x\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nx.\n\n## Notes\n\n',
+      journalFilename: '2026-04-28-10-00.md',
+      journalBody: '# Session 2026-04-28T10:00:00.000Z\n\n## Goal\nx.\n',
+    })
+
+    const result = await runSession({
+      db: db.db,
+      config,
+      project,
+      claudeBin: MOCK_CLAUDE,
+      githubClient: gh,
+      skipClaudeProbe: true,
+    })
+
+    expect(['quality-gate-failed', 'completed']).toContain(result.status)
+    if (result.status === 'quality-gate-failed') {
+      // No PR opened on quality-gate-failed
+      expect(result.prNumber).toBeNull()
+      expect(gh.created).toHaveLength(0)
+      expect(result.fixupTurnRan).toBe(true)
+    }
+  }, 90_000)
+
+  it('refuses to run a second session for the same project (lock)', async () => {
+    harness = await setupHarness('all-good')
+    const { db, config, slug, projectId } = harness
+    const projects = new ProjectRepository(db.db)
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    // Take the lock manually to simulate a concurrent session.
+    db.db
+      .prepare('INSERT INTO project_locks (project_id, session_id, pid) VALUES (?, ?, ?)')
+      .run(projectId, 'other-session', process.pid)
+
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({})
+
+    await expect(
+      runSession({
+        db: db.db,
+        config,
+        project,
+        claudeBin: MOCK_CLAUDE,
+        githubClient: fakeGitHub(),
+        skipClaudeProbe: true,
+      }),
+    ).rejects.toMatchObject({ code: 'PROJECT_LOCKED' })
+  })
+})

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -1,12 +1,74 @@
-// Session worker — spawns Claude Code, enforces the time budget, runs quality
-// gates, commits, and opens a PR. This is Phase 1 work (see PRODUCT_VISION.md
-// "Phase 1: Manual Single-Project Sessions"). The Phase 0 file is a stub so
-// the rest of the system can import it.
+// Session worker — the heart of Phase 1.
+//
+// runSession(...) executes the 12 steps described in CLAUDE.md:
+//   1.  Acquire the per-project advisory lock                       (locks)
+//   2.  Prepare the working directory (clone or refresh)            (git)
+//   3.  Read .maestro/ files and validate with Zod                  (state-manager)
+//   4.  Build the session prompt                                    (shared/prompt-templates)
+//   5.  Spawn `claude` and capture stream output                    (claude-runner)
+//   6.  Enforce time budget with SIGTERM-then-SIGKILL choreography  (claude-runner)
+//   7.  Verify the agent committed work + touched .maestro/         (state-manager + git)
+//   8.  Run quality gates                                           (quality-gates)
+//   9.  Optional fixup turn if gates failed                         (claude-runner again)
+//   10. Push branch and open PR (or apply needs-review label)       (pr-manager)
+//   11. Persist the session row                                     (repositories)
+//   12. Cleanup intent (we keep working dirs for inspection)
+//
+// Tests inject a mock `claudeBin` via options so the suite never spawns
+// the real CLI. Production calls pass the real `claude` path through
+// the env (DEFAULT: just "claude").
 
+import { existsSync } from 'node:fs'
+import { mkdir, rm } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
 import type Database from 'better-sqlite3'
-import type { Project } from '@maestro/shared'
-import { MaestroError } from '@maestro/shared'
+import simpleGit, { type SimpleGit } from 'simple-git'
+import {
+  FIXUP_TURN_BUDGET_SECONDS,
+  LOGS_SUBDIR,
+  MaestroError,
+  PROMPT_VERSION,
+  WORK_SUBDIR,
+  buildFixupTurnPrompt,
+  buildSessionPrompt,
+  type Project,
+  type SessionStatus,
+  type SessionResult,
+  type QualityGate,
+} from '@maestro/shared'
 import type { Config } from './config.js'
+import { logger } from './logger.js'
+import {
+  ProjectLockManager,
+} from './locks.js'
+import {
+  ProjectRepository,
+  QualityGateRepository,
+  SessionRepository,
+} from './repositories.js'
+import {
+  listRecentJournal,
+  readMaestroDir,
+  snapshotMaestroDir,
+  verifyAgentTouchedMaestroDir,
+} from './state-manager.js'
+import {
+  ensureClaudeAvailable,
+  runClaudeSession,
+  type ClaudeRunResult,
+} from './claude-runner.js'
+import {
+  runQualityGates,
+  type SingleGateResult,
+} from './quality-gates.js'
+import {
+  createGitHubClient,
+  parseRepoUrl,
+  type GitHubClient,
+} from './pr-manager.js'
+
+// ─── Public types ────────────────────────────────────────────────────
 
 export interface RunSessionInput {
   db: Database.Database
@@ -14,10 +76,465 @@ export interface RunSessionInput {
   project: Project
   /** When true, build the prompt and log it without spawning Claude. */
   dryRun?: boolean
+  /**
+   * Override the claude binary. Tests pass a path to a mock executable;
+   * production passes nothing and the runner uses `claude`.
+   */
+  claudeBin?: string
+  /**
+   * Inject a GitHub client. Tests pass a mock; production constructs
+   * one from config.githubToken.
+   */
+  githubClient?: GitHubClient
+  /**
+   * Skip the live `claude --version` check. Used by tests.
+   */
+  skipClaudeProbe?: boolean
 }
 
-export async function runSession(_input: RunSessionInput): Promise<never> {
-  throw new MaestroError('INTERNAL_ERROR', {
-    message: 'runSession is Phase 1 work. See PRODUCT_VISION.md.',
+export interface RunSessionOutput extends SessionResult {
+  /** Path to the freshly-written log file. */
+  logPath: string
+  /** Whether the worker spawned a fixup turn. */
+  fixupTurnRan: boolean
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────
+
+export async function runSession(input: RunSessionInput): Promise<RunSessionOutput> {
+  const sessionId = randomUUID()
+  const sessions = new SessionRepository(input.db)
+  const gates = new QualityGateRepository(input.db)
+  const locks = new ProjectLockManager(input.db)
+  const projects = new ProjectRepository(input.db)
+
+  // Pre-flight ------------------------------------------------------------------------
+  if (!input.dryRun && !input.skipClaudeProbe) {
+    await ensureClaudeAvailable(input.claudeBin)
+  }
+
+  // Step 1: lock --------------------------------------------------------------------
+  if (!input.dryRun) locks.acquire(input.project.id, sessionId)
+
+  const sessionRow = input.dryRun
+    ? null
+    : sessions.insert({
+        id: sessionId,
+        projectId: input.project.id,
+        promptVersion: PROMPT_VERSION,
+      })
+
+  let result: RunSessionOutput | null = null
+  try {
+    result = await runSessionInner({
+      ...input,
+      sessionId,
+      sessions,
+      gates,
+      projects,
+    })
+    return result
+  } catch (err) {
+    if (sessionRow) {
+      sessions.update(sessionId, {
+        status: 'failed',
+        endedAt: new Date().toISOString(),
+        terminationCause: 'failed',
+      })
+    }
+    throw err
+  } finally {
+    if (!input.dryRun) locks.release(input.project.id, sessionId)
+  }
+}
+
+interface InnerInput extends RunSessionInput {
+  sessionId: string
+  sessions: SessionRepository
+  gates: QualityGateRepository
+  projects: ProjectRepository
+}
+
+async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
+  const { project, config } = input
+  const workingRoot = workingDirFor(config.dataDir, project.slug)
+  const logPath = sessionLogPath(config.dataDir, input.sessionId)
+
+  // Step 2: working directory ------------------------------------------------------
+  await prepareWorkingDir({
+    workingRoot,
+    repoUrl: project.repoUrl,
+    baseBranch: project.autonomyConfig.branches.base,
+    developerName: config.developerName,
+    developerEmail: config.developerEmail ?? `${config.developerGithubUsername}@users.noreply.github.com`,
+  })
+
+  // Step 3: read .maestro/ ----------------------------------------------------------
+  const maestro = await readMaestroDir(workingRoot)
+  const recentJournal = await listRecentJournal(workingRoot, 3)
+
+  // Step 4: build prompt ------------------------------------------------------------
+  const task = deriveTaskFromState(maestro.state.raw)
+  const prompt = buildSessionPrompt({
+    projectName: project.slug,
+    projectSlug: project.slug,
+    timeBudgetSeconds: project.autonomyConfig.timeBudget,
+    developerName: config.developerName,
+    context: maestro.context,
+    state: maestro.state.raw,
+    recentJournal: recentJournal.map((j) => ({ filename: j.filename, body: j.body })),
+    task,
+    qualityGates: project.autonomyConfig.qualityGates,
+    isFirstSession: recentJournal.length === 0,
+  })
+
+  if (input.dryRun) {
+    logger.info({ projectSlug: project.slug, promptBytes: prompt.length }, 'dry-run prompt')
+    process.stdout.write(prompt)
+    process.stdout.write('\n')
+    return {
+      sessionId: input.sessionId,
+      status: 'completed',
+      filesChanged: [],
+      commitSha: null,
+      branchName: null,
+      prNumber: null,
+      qualityGates: [],
+      costCents: null,
+      journalPath: null,
+      notes: 'dry-run — prompt printed, no session spawned',
+      logPath,
+      fixupTurnRan: false,
+    }
+  }
+
+  // Snapshot .maestro/ so we can verify the agent touched it later.
+  const before = await snapshotMaestroDir(workingRoot)
+
+  input.sessions.update(input.sessionId, {
+    status: 'running',
+    logPath,
+  })
+
+  // Step 5–6: spawn Claude with budget --------------------------------------------
+  const runResult = await runClaudeSession({
+    cwd: workingRoot,
+    prompt,
+    timeBudgetSeconds: project.autonomyConfig.timeBudget,
+    logPath,
+    claudeBin: input.claudeBin,
+  })
+  logRunResult(runResult)
+
+  // Step 7: post-session validation ------------------------------------------------
+  const git = simpleGit(workingRoot)
+  const branch = (await git.branch()).current
+  const branchOk = branch !== project.autonomyConfig.branches.base
+  const filesChanged = (await git.diff(['--name-only', `${project.autonomyConfig.branches.base}...HEAD`]))
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const headSha = (await git.revparse(['HEAD'])).trim()
+  const touchedMaestro = await verifyAgentTouchedMaestroDir(workingRoot, before)
+
+  // Tracked across the rest of this function so the final status report can
+  // accurately tell the developer whether a fixup turn actually fired.
+  let didRunFixupTurn = false
+
+  const baseFinalize = (
+    status: SessionStatus,
+    extra: Partial<SessionResult> = {},
+  ): RunSessionOutput => {
+    const updated = input.sessions.update(input.sessionId, {
+      status,
+      endedAt: new Date().toISOString(),
+      branchName: branchOk ? branch : null,
+      modelUsed: runResult.modelUsed,
+      costCents: runResult.costCents,
+      terminationCause: runResult.terminationCause,
+      journalPath: touchedMaestro.newJournalFile
+        ? join('.maestro', 'journal', touchedMaestro.newJournalFile)
+        : null,
+      ...extra,
+    })
+    void updated
+    return {
+      sessionId: input.sessionId,
+      status,
+      filesChanged,
+      commitSha: filesChanged.length > 0 ? headSha : null,
+      branchName: branchOk ? branch : null,
+      prNumber: extra.prNumber ?? null,
+      qualityGates: input.gates.listForSession(input.sessionId),
+      costCents: runResult.costCents,
+      journalPath: touchedMaestro.newJournalFile
+        ? join('.maestro', 'journal', touchedMaestro.newJournalFile)
+        : null,
+      notes: extra.notes ?? null,
+      logPath,
+      fixupTurnRan: didRunFixupTurn,
+    }
+  }
+
+  if (filesChanged.length === 0) {
+    return baseFinalize('completed-no-changes', {
+      notes: 'agent ran but produced no committed changes',
+    })
+  }
+  if (!branchOk) {
+    return baseFinalize('failed', {
+      notes: `agent committed to ${branch} (must be a feature branch)`,
+    })
+  }
+  if (!touchedMaestro.stateUpdated || !touchedMaestro.journalAppended) {
+    return baseFinalize('failed', {
+      notes: `agent skipped required .maestro/ updates (state=${touchedMaestro.stateUpdated}, journal=${touchedMaestro.journalAppended})`,
+    })
+  }
+
+  // Step 8: quality gates ---------------------------------------------------------
+  const gateRun = await runQualityGates({
+    projectRoot: workingRoot,
+    gates: project.autonomyConfig.qualityGates,
+  })
+  recordGateResults(input.sessionId, input.gates, gateRun.results)
+
+  // Step 9: fixup turn ------------------------------------------------------------
+  let secondGateRun = gateRun
+  if (!gateRun.allPassed) {
+    didRunFixupTurn = true
+    const failureOutput = gateRun.results
+      .filter((r) => r.status === 'failed')
+      .map((r) => `## ${r.gate}\n\n${r.output}`)
+      .join('\n\n')
+    const fixupPrompt = buildFixupTurnPrompt({
+      projectName: project.slug,
+      timeBudgetSeconds: FIXUP_TURN_BUDGET_SECONDS,
+      failureOutput,
+    })
+    const fixupSessionId = `${input.sessionId}-fixup`
+    const fixupRow = input.sessions.insert({
+      id: fixupSessionId,
+      projectId: project.id,
+      promptVersion: PROMPT_VERSION,
+      isFixupTurn: true,
+      parentSessionId: input.sessionId,
+    })
+    void fixupRow
+    const fixupLogPath = sessionLogPath(config.dataDir, fixupSessionId)
+    const fixupResult = await runClaudeSession({
+      cwd: workingRoot,
+      prompt: fixupPrompt,
+      timeBudgetSeconds: FIXUP_TURN_BUDGET_SECONDS,
+      logPath: fixupLogPath,
+      claudeBin: input.claudeBin,
+    })
+    logRunResult(fixupResult)
+    input.sessions.update(fixupSessionId, {
+      status: fixupResult.exitCode === 0 ? 'completed' : 'failed',
+      endedAt: new Date().toISOString(),
+      logPath: fixupLogPath,
+      modelUsed: fixupResult.modelUsed,
+      costCents: fixupResult.costCents,
+      terminationCause: fixupResult.terminationCause,
+    })
+    secondGateRun = await runQualityGates({
+      projectRoot: workingRoot,
+      gates: project.autonomyConfig.qualityGates,
+    })
+    recordGateResults(fixupSessionId, input.gates, secondGateRun.results)
+  }
+
+  // Step 10: PR creation ----------------------------------------------------------
+  const baseBranch = project.autonomyConfig.branches.base
+  await git.push(['-u', 'origin', branch])
+
+  const githubClient =
+    input.githubClient ??
+    (config.githubToken
+      ? createGitHubClient({ token: config.githubToken })
+      : null)
+
+  if (!secondGateRun.allPassed) {
+    if (githubClient) {
+      try {
+        const repo = parseRepoUrl(project.repoUrl)
+        const open = await githubClient.listOpenPullRequests(repo)
+        const existing = open.find((pr) => pr.branchName === branch)
+        if (existing) {
+          await githubClient.addLabels({
+            repo,
+            prNumber: existing.number,
+            labels: ['quality-gates-failed'],
+          })
+        }
+      } catch (err) {
+        logger.warn({ err }, 'could not label PR on quality-gate failure')
+      }
+    }
+    return baseFinalize('quality-gate-failed', {
+      notes: 'quality gates failed; branch pushed without PR',
+    })
+  }
+
+  if (!githubClient) {
+    return baseFinalize('completed', {
+      notes: 'GITHUB_TOKEN not configured; branch pushed but PR not opened',
+    })
+  }
+
+  let repo
+  try {
+    repo = parseRepoUrl(project.repoUrl)
+  } catch (err) {
+    logger.warn({ err, repoUrl: project.repoUrl }, 'cannot parse repo URL — branch pushed without PR')
+    return baseFinalize('completed', {
+      notes: 'branch pushed; PR not opened (non-GitHub URL)',
+    })
+  }
+
+  const lastCommitSubject = (await git.log({ maxCount: 1 })).latest?.message ?? ''
+  const title = lastCommitSubject || `Maestro: ${input.sessionId}`
+  const journalRef = touchedMaestro.newJournalFile
+    ? `\n\n_Session journal: \`.maestro/journal/${touchedMaestro.newJournalFile}\`_`
+    : ''
+  const gateSummary = secondGateRun.results
+    .map((r) => `- **${r.gate}**: ${r.status}${r.durationMs ? ` (${Math.round(r.durationMs / 1000)}s)` : ''}`)
+    .join('\n')
+  const body = [
+    `Drafted by Maestro session \`${input.sessionId}\`. Reviewed and merged by the developer.`,
+    '',
+    '### Quality gates',
+    gateSummary,
+    journalRef,
+  ].join('\n')
+
+  const pr = await githubClient.createPullRequest({
+    repo,
+    branchName: branch,
+    baseBranch,
+    title,
+    body,
+    draft:
+      project.autonomyConfig.level === 'draft-only' ||
+      project.autonomyConfig.github.draftByDefault,
+    labels: project.autonomyConfig.github.prLabels,
+  })
+
+  return baseFinalize('completed', {
+    prNumber: pr.number,
+    notes: pr.url,
   })
 }
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function workingDirFor(dataDir: string, slug: string): string {
+  return resolve(dataDir, WORK_SUBDIR, slug)
+}
+
+function sessionLogPath(dataDir: string, sessionId: string): string {
+  return resolve(dataDir, LOGS_SUBDIR, `${sessionId}.log`)
+}
+
+function logRunResult(r: ClaudeRunResult): void {
+  logger.info(
+    {
+      exitCode: r.exitCode,
+      signal: r.signal,
+      terminationCause: r.terminationCause,
+      durationMs: r.durationMs,
+      modelUsed: r.modelUsed,
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      costCents: r.costCents,
+    },
+    'claude session finished',
+  )
+}
+
+function recordGateResults(
+  sessionId: string,
+  repo: QualityGateRepository,
+  results: SingleGateResult[],
+): void {
+  for (const r of results) {
+    repo.insert({
+      sessionId,
+      gateName: r.gate,
+      status: r.status,
+      output: r.output,
+      durationMs: r.durationMs,
+    })
+  }
+}
+
+interface PrepareWorkingDirInput {
+  workingRoot: string
+  repoUrl: string
+  baseBranch: string
+  developerName: string
+  developerEmail: string
+}
+
+async function prepareWorkingDir(input: PrepareWorkingDirInput): Promise<void> {
+  await mkdir(dirname(input.workingRoot), { recursive: true })
+  const exists = existsSync(input.workingRoot)
+  const hasGit = exists && existsSync(join(input.workingRoot, '.git'))
+
+  if (hasGit) {
+    try {
+      const git = simpleGit(input.workingRoot)
+      await git.fetch(['--all', '--prune'])
+      await git.checkout(input.baseBranch)
+      await git.reset(['--hard', `origin/${input.baseBranch}`])
+      await git.clean('f', ['-d', '-x'])
+      await configureGitIdentity(git, input.developerName, input.developerEmail)
+      return
+    } catch (err) {
+      logger.warn({ err, dir: input.workingRoot }, 're-init working dir from scratch')
+      await rm(input.workingRoot, { recursive: true, force: true })
+    }
+  } else if (exists) {
+    await rm(input.workingRoot, { recursive: true, force: true })
+  }
+
+  const git = simpleGit(dirname(input.workingRoot))
+  try {
+    await git.clone(input.repoUrl, input.workingRoot, ['--branch', input.baseBranch])
+  } catch (err) {
+    throw new MaestroError('GIT_OPERATION_FAILED', {
+      message: `Failed to clone ${input.repoUrl}`,
+      cause: err,
+      context: { workingRoot: input.workingRoot, repoUrl: input.repoUrl },
+    })
+  }
+  await configureGitIdentity(simpleGit(input.workingRoot), input.developerName, input.developerEmail)
+}
+
+async function configureGitIdentity(git: SimpleGit, name: string, email: string): Promise<void> {
+  await git.addConfig('user.name', name, false, 'local')
+  await git.addConfig('user.email', email, false, 'local')
+}
+
+/**
+ * Pull a single concrete task out of state.md by reading the first
+ * unchecked checkbox under "Next Concrete Tasks". Falls back to a
+ * permissive note that lets the agent decide.
+ */
+function deriveTaskFromState(stateMd: string): string {
+  const sectionMatch = /##\s*Next Concrete Tasks\s*\n([\s\S]*?)(\n##\s|$)/.exec(stateMd)
+  const body = sectionMatch?.[1] ?? ''
+  const firstUnchecked = /^-\s*\[\s*\]\s*(.+)$/m.exec(body)
+  if (firstUnchecked?.[1]) {
+    return firstUnchecked[1].trim()
+  }
+  return 'Pick the most important task from state.md "Next Concrete Tasks" — or do nothing and explain why in the journal.'
+}
+
+// ─── Re-exports for tests ────────────────────────────────────────────
+
+export { sessionLogPath, workingDirFor, deriveTaskFromState }
+
+// Type re-export so call-sites can pin to the local definition.
+export type WorkerQualityGate = QualityGate

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@maestro/api": "workspace:*",

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from './components/Layout'
 import { Overview } from './pages/Overview'
 import { ProjectDetail } from './pages/ProjectDetail'
 import { Sessions } from './pages/Sessions'
+import { SessionDetail } from './pages/SessionDetail'
 import { PRs } from './pages/PRs'
 import { Settings } from './pages/Settings'
 
@@ -13,6 +14,7 @@ export function App() {
         <Route index element={<Overview />} />
         <Route path="projects/:slug" element={<ProjectDetail />} />
         <Route path="sessions" element={<Sessions />} />
+        <Route path="sessions/:id" element={<SessionDetail />} />
         <Route path="prs" element={<PRs />} />
         <Route path="settings" element={<Settings />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/packages/dashboard/src/lib/format.ts
+++ b/packages/dashboard/src/lib/format.ts
@@ -1,0 +1,40 @@
+// Tiny presentation helpers. Kept out of components so they can be reused
+// and tested independently if/when we add tests for the dashboard.
+
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function formatDuration(start: string, end: string | null | undefined): string {
+  if (!end) return 'in progress'
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  if (Number.isNaN(ms) || ms < 0) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  if (m < 60) return `${m}m ${s}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+export function statusLabel(status: string): string {
+  return status.replace(/-/g, ' ')
+}
+
+export function gateTag(status: string): string {
+  return status === 'passed' ? '✓' : status === 'failed' ? '✗' : '∼'
+}

--- a/packages/dashboard/src/pages/Overview.tsx
+++ b/packages/dashboard/src/pages/Overview.tsx
@@ -1,18 +1,25 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ListProjectsResponse, ListSessionsResponse } from '@maestro/api'
 import { useApi } from '../hooks/useApi'
-import type { ListProjectsResponse } from '@maestro/api'
+import { formatDateTime, formatDuration, statusLabel } from '../lib/format'
 
 export function Overview() {
   const api = useApi()
-  const [data, setData] = useState<ListProjectsResponse | null>(null)
+  const [projects, setProjects] = useState<ListProjectsResponse | null>(null)
+  const [sessions, setSessions] = useState<ListSessionsResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
-    void api
-      .get<ListProjectsResponse>('/api/projects')
-      .then((res) => {
-        if (!cancelled) setData(res)
+    void Promise.all([
+      api.get<ListProjectsResponse>('/api/projects'),
+      api.get<ListSessionsResponse>('/api/sessions?limit=5'),
+    ])
+      .then(([p, s]) => {
+        if (cancelled) return
+        setProjects(p)
+        setSessions(s)
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Unknown error')
@@ -23,33 +30,89 @@ export function Overview() {
   }, [api])
 
   return (
-    <section className="mx-auto max-w-6xl">
-      <header className="mb-8">
+    <section className="mx-auto max-w-6xl space-y-8">
+      <header>
         <p className="text-xs uppercase tracking-[0.2em] text-amber-500">Projects</p>
         <h2 className="mt-1 text-2xl font-semibold text-white">Overview</h2>
         <p className="mt-1 text-sm text-navy-300">
-          All projects under Maestro management. Each card surfaces current state, recent
-          activity, and pending review.
+          All projects under Maestro management. Each card surfaces current autonomy and
+          recent activity.
         </p>
       </header>
 
       {error ? <ErrorCard message={error} /> : null}
 
-      {!data ? (
+      {!projects ? (
         <SkeletonGrid />
-      ) : data.projects.length === 0 ? (
+      ) : projects.projects.length === 0 ? (
         <EmptyState />
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {data.projects.map((p) => (
-            <article key={p.id} className="panel p-5">
-              <h3 className="font-mono text-sm text-navy-200">{p.slug}</h3>
-              <p className="mt-2 text-xs text-navy-400">{p.repoUrl}</p>
-              <span className="pill pill-amber mt-4">{p.autonomyConfig.level}</span>
-            </article>
+          {projects.projects.map((p) => (
+            <Link key={p.id} to={`/projects/${p.slug}`} className="panel block p-5 transition hover:border-amber-700/60">
+              <div className="flex items-center justify-between">
+                <h3 className="font-mono text-sm text-navy-100">{p.slug}</h3>
+                <span className="pill pill-amber">{p.autonomyConfig.level}</span>
+              </div>
+              <p className="mt-2 truncate text-xs text-navy-400">{p.repoUrl}</p>
+              <dl className="mt-4 grid grid-cols-2 gap-2 text-xs">
+                <div>
+                  <dt className="text-navy-400">Schedule</dt>
+                  <dd className="font-mono text-navy-200">{p.autonomyConfig.schedule}</dd>
+                </div>
+                <div>
+                  <dt className="text-navy-400">Budget</dt>
+                  <dd className="text-navy-200">
+                    {Math.round(p.autonomyConfig.timeBudget / 60)}m
+                  </dd>
+                </div>
+                <div className="col-span-2">
+                  <dt className="text-navy-400">Gates</dt>
+                  <dd className="font-mono text-navy-200">
+                    {p.autonomyConfig.qualityGates.join(', ')}
+                  </dd>
+                </div>
+              </dl>
+            </Link>
           ))}
         </div>
       )}
+
+      {sessions && sessions.sessions.length > 0 ? (
+        <div>
+          <header className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-navy-100">Recent sessions</h3>
+            <Link to="/sessions" className="text-xs text-amber-400 hover:underline">
+              all sessions →
+            </Link>
+          </header>
+          <div className="panel divide-y divide-navy-700/70">
+            {sessions.sessions.map((s) => (
+              <Link
+                key={s.id}
+                to={`/sessions/${s.id}`}
+                className="flex items-center justify-between gap-4 px-5 py-3 transition hover:bg-navy-700/30"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-3">
+                    <span className="pill">{statusLabel(s.status)}</span>
+                    <span className="font-mono text-sm text-navy-100">{s.id.slice(0, 8)}</span>
+                  </div>
+                  <div className="mt-1 truncate text-xs text-navy-400">
+                    {s.branchName ?? '(no branch)'}
+                  </div>
+                </div>
+                <div className="text-right text-xs text-navy-300">
+                  <div>{formatDateTime(s.startedAt)}</div>
+                  <div className="text-navy-400">
+                    {formatDuration(s.startedAt, s.endedAt)}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </section>
   )
 }
@@ -71,11 +134,11 @@ function EmptyState() {
       </div>
       <h3 className="text-lg font-semibold text-white">No projects yet</h3>
       <p className="mt-2 max-w-md text-sm text-navy-300">
-        Add a repository to put it under autonomous management. The first session is for
-        orientation — no code changes, just observation.
+        Initialise <code>.maestro/</code> in a repo and register it. The first session is for
+        orientation only — no code changes, just observation.
       </p>
       <pre className="mt-6 inline-block rounded-lg border border-navy-700 bg-navy-950/70 px-4 py-2 text-xs text-amber-200">
-        maestro add &lt;repo-url&gt;
+        maestro init &lt;path&gt;{'\n'}maestro add &lt;repo-url&gt;
       </pre>
     </div>
   )

--- a/packages/dashboard/src/pages/PRs.tsx
+++ b/packages/dashboard/src/pages/PRs.tsx
@@ -5,8 +5,8 @@ export function PRs() {
     <Placeholder
       eyebrow="Review queue"
       title="Pull Requests"
-      body="One-click review of every PR Maestro opened on your behalf. Lands in Phase 3 with the dashboard."
-      reference="PRODUCT_VISION.md → Phase 3"
+      body="One-click review of every PR Maestro opened on your behalf. Real implementation lands in Phase 1.5."
+      reference="PRODUCT_VISION.md → Phase 3 (foundations land in Phase 1.5)"
     />
   )
 }

--- a/packages/dashboard/src/pages/ProjectDetail.tsx
+++ b/packages/dashboard/src/pages/ProjectDetail.tsx
@@ -7,8 +7,8 @@ export function ProjectDetail() {
     <Placeholder
       eyebrow="Projects"
       title={slug ? `Project: ${slug}` : 'Project'}
-      body="Per-project view: state, journal, sessions, autonomy. Lands in Phase 3."
-      reference="PRODUCT_VISION.md → Phase 3"
+      body="Per-project view: state, journal, sessions, autonomy. Lands in Phase 1.5."
+      reference="PRODUCT_VISION.md → Phase 3 (foundations land in Phase 1.5)"
     />
   )
 }

--- a/packages/dashboard/src/pages/SessionDetail.tsx
+++ b/packages/dashboard/src/pages/SessionDetail.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import type { GetSessionResponse, SessionLogResponse } from '@maestro/api'
+import { useApi } from '../hooks/useApi'
+import { formatDateTime, formatDuration, gateTag, statusLabel } from '../lib/format'
+
+export function SessionDetail() {
+  const { id } = useParams<{ id: string }>()
+  const api = useApi()
+  const [data, setData] = useState<GetSessionResponse | null>(null)
+  const [log, setLog] = useState<SessionLogResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    void Promise.all([
+      api.get<GetSessionResponse>(`/api/sessions/${encodeURIComponent(id)}`),
+      api.get<SessionLogResponse>(`/api/sessions/${encodeURIComponent(id)}/log`),
+    ])
+      .then(([detail, l]) => {
+        if (cancelled) return
+        setData(detail)
+        setLog(l)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'unknown error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api, id])
+
+  if (error) {
+    return (
+      <section className="mx-auto max-w-4xl">
+        <div className="panel border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+          {error}
+        </div>
+      </section>
+    )
+  }
+  if (!data) return <Skeleton />
+
+  const { session, qualityGates } = data
+
+  return (
+    <section className="mx-auto max-w-4xl space-y-6">
+      <header>
+        <Link to="/sessions" className="text-xs text-amber-400 hover:underline">
+          ← all sessions
+        </Link>
+        <h2 className="mt-2 font-mono text-lg text-white">{session.id}</h2>
+        <p className="text-xs uppercase tracking-[0.2em] text-amber-500">
+          Session · {statusLabel(session.status)}
+        </p>
+      </header>
+
+      <div className="panel grid grid-cols-1 gap-4 px-5 py-4 text-sm sm:grid-cols-2">
+        <Field label="Project" value={session.projectId} />
+        <Field label="Status" value={statusLabel(session.status)} />
+        <Field label="Started" value={formatDateTime(session.startedAt)} />
+        <Field label="Ended" value={formatDateTime(session.endedAt)} />
+        <Field label="Duration" value={formatDuration(session.startedAt, session.endedAt)} />
+        <Field label="Branch" value={session.branchName ?? '—'} mono />
+        <Field
+          label="PR"
+          value={session.prNumber !== null ? `#${session.prNumber}` : '—'}
+        />
+        <Field label="PR URL" value={session.prUrl ?? '—'} mono />
+        <Field label="Termination" value={session.terminationCause ?? '—'} mono />
+        <Field
+          label="Cost"
+          value={
+            session.costCents !== null ? `$${(session.costCents / 100).toFixed(2)}` : '—'
+          }
+        />
+        <Field label="Model" value={session.modelUsed ?? '—'} mono />
+        <Field label="Prompt version" value={session.promptVersion} mono />
+        <Field label="Journal" value={session.journalPath ?? '—'} mono />
+        <Field label="Log path" value={session.logPath ?? '—'} mono />
+      </div>
+
+      <div className="panel">
+        <header className="panel-header">
+          <h3 className="font-medium text-white">Quality gates</h3>
+          <span className="text-xs text-navy-400">{qualityGates.length} run</span>
+        </header>
+        <div className="divide-y divide-navy-700/70">
+          {qualityGates.length === 0 ? (
+            <p className="px-5 py-4 text-sm text-navy-300">No gates ran for this session.</p>
+          ) : (
+            qualityGates.map((g, i) => (
+              <details key={i} className="px-5 py-3">
+                <summary className="flex cursor-pointer items-center gap-3">
+                  <span className="font-mono text-sm">{gateTag(g.status)}</span>
+                  <span className="text-sm font-medium text-navy-100">{g.gateName}</span>
+                  <span className="ml-auto text-xs text-navy-400">
+                    {g.durationMs ? `${Math.round(g.durationMs / 1000)}s` : ''}
+                  </span>
+                </summary>
+                <pre className="mt-3 max-h-72 overflow-auto rounded-lg border border-navy-700 bg-navy-950/70 p-3 text-xs leading-relaxed text-navy-200">
+                  {g.output || '(no output captured)'}
+                </pre>
+              </details>
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="panel">
+        <header className="panel-header">
+          <h3 className="font-medium text-white">Log tail</h3>
+          {log?.sizeBytes !== undefined ? (
+            <span className="text-xs text-navy-400">
+              {(log.sizeBytes / 1024).toFixed(1)} KB total
+              {log.truncated ? ' · truncated' : ''}
+            </span>
+          ) : null}
+        </header>
+        <pre className="max-h-[420px] overflow-auto px-5 py-4 text-xs leading-relaxed text-navy-200">
+          {log?.available ? log.tail : '(log not available)'}
+        </pre>
+      </div>
+    </section>
+  )
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-navy-400">{label}</div>
+      <div className={mono ? 'font-mono text-navy-100' : 'text-navy-100'}>{value}</div>
+    </div>
+  )
+}
+
+function Skeleton() {
+  return (
+    <section className="mx-auto max-w-4xl space-y-6">
+      <div className="panel h-32 animate-pulse" />
+      <div className="panel h-48 animate-pulse" />
+      <div className="panel h-64 animate-pulse" />
+    </section>
+  )
+}

--- a/packages/dashboard/src/pages/Sessions.tsx
+++ b/packages/dashboard/src/pages/Sessions.tsx
@@ -1,12 +1,134 @@
-import { Placeholder } from './_Placeholder'
+import { useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import type { ListSessionsResponse } from '@maestro/api'
+import { useApi } from '../hooks/useApi'
+import { formatDuration, formatDateTime, statusLabel } from '../lib/format'
 
 export function Sessions() {
+  const api = useApi()
+  const [params, setParams] = useSearchParams()
+  const projectId = params.get('projectId') ?? undefined
+  const [data, setData] = useState<ListSessionsResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const url = projectId
+      ? `/api/sessions?projectId=${encodeURIComponent(projectId)}`
+      : '/api/sessions'
+    api
+      .get<ListSessionsResponse>(url)
+      .then((res) => {
+        if (!cancelled) setData(res)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'unknown error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api, projectId])
+
   return (
-    <Placeholder
-      eyebrow="Activity"
-      title="Sessions"
-      body="Session history across every managed project. Each session lists what the agent did, why, and what worked. Lands in Phase 3."
-      reference="PRODUCT_VISION.md → Phase 3"
-    />
+    <section className="mx-auto max-w-6xl">
+      <header className="mb-8 flex items-end justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-amber-500">Activity</p>
+          <h2 className="mt-1 text-2xl font-semibold text-white">Sessions</h2>
+          <p className="mt-1 text-sm text-navy-300">
+            Every Maestro-driven session, newest first. Click into one to see the full log,
+            quality-gate output, and journal entry.
+          </p>
+        </div>
+        {projectId ? (
+          <button
+            onClick={() => setParams({})}
+            className="text-xs text-amber-400 hover:underline"
+          >
+            clear project filter
+          </button>
+        ) : null}
+      </header>
+
+      {error ? (
+        <div className="panel mb-6 border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {!data ? (
+        <SkeletonList />
+      ) : data.sessions.length === 0 ? (
+        <Empty />
+      ) : (
+        <div className="panel divide-y divide-navy-700/70">
+          {data.sessions.map((s) => (
+            <Link
+              key={s.id}
+              to={`/sessions/${s.id}`}
+              className="flex items-center justify-between gap-4 px-5 py-3 transition hover:bg-navy-700/30"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-3">
+                  <span className={`pill ${pillFor(s.status)}`}>{statusLabel(s.status)}</span>
+                  <span className="font-mono text-sm text-navy-100">{s.id.slice(0, 8)}</span>
+                  {s.isFixupTurn ? <span className="pill">fixup</span> : null}
+                </div>
+                <div className="mt-1 truncate text-xs text-navy-400">
+                  {s.branchName ?? '(no branch)'} · model {s.modelUsed ?? '—'}
+                </div>
+              </div>
+              <div className="text-right text-xs text-navy-300">
+                <div>{formatDateTime(s.startedAt)}</div>
+                <div className="text-navy-400">
+                  {formatDuration(s.startedAt, s.endedAt)}
+                  {s.prNumber !== null ? `  ·  PR #${s.prNumber}` : ''}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
   )
+}
+
+function Empty() {
+  return (
+    <div className="panel px-6 py-16 text-center">
+      <h3 className="text-lg font-semibold text-white">No sessions yet</h3>
+      <p className="mt-2 text-sm text-navy-300">
+        Trigger a session from the CLI:{' '}
+        <code className="rounded bg-navy-950/70 px-2 py-0.5 text-amber-200">
+          maestro run &lt;slug&gt;
+        </code>
+      </p>
+    </div>
+  )
+}
+
+function SkeletonList() {
+  return (
+    <div className="panel divide-y divide-navy-700/70">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="h-16 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+function pillFor(status: string): string {
+  switch (status) {
+    case 'completed':
+      return 'pill-success'
+    case 'failed':
+    case 'quality-gate-failed':
+    case 'timed-out':
+      return 'border-danger/60 bg-danger/10 text-danger'
+    case 'running':
+    case 'pending':
+      return 'pill-amber'
+    default:
+      return ''
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -b",
     "dev": "tsc -b --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,3 +73,41 @@ export const JOURNAL_LOOKBACK_ENTRIES = 3
 export const DEFAULT_PORT = 3000
 
 export const DEFAULT_DATA_DIR = './data'
+
+// ─── Working directories ─────────────────────────────────────────────
+
+// Where per-project clones live, relative to MAESTRO_DATA_DIR.
+export const WORK_SUBDIR = 'work'
+
+// Where session log files live, relative to MAESTRO_DATA_DIR.
+export const LOGS_SUBDIR = 'logs/sessions'
+
+// ─── Quality gates ───────────────────────────────────────────────────
+
+// Per-gate timeout (seconds). Default 5 minutes.
+export const DEFAULT_QUALITY_GATE_TIMEOUT_SECONDS = 5 * 60
+
+// Number of trailing output lines stored in the database for each gate
+// run. The full output goes to the session log file.
+export const QUALITY_GATE_OUTPUT_TAIL_LINES = 200
+
+// ─── Project stacks ──────────────────────────────────────────────────
+
+// Stacks Maestro can detect from the project root. Used to decide which
+// commands to run for each quality gate when no explicit override exists.
+export const PROJECT_STACKS = [
+  'pnpm',
+  'npm',
+  'yarn',
+  'bun',
+  'python-poetry',
+  'python-pip',
+  'rust-cargo',
+  'go-mod',
+  'unknown',
+] as const
+
+// ─── Sessions ────────────────────────────────────────────────────────
+
+// Session log tail size returned to the dashboard. Bigger requests stream.
+export const SESSION_LOG_TAIL_LINES = 500

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -67,6 +67,15 @@ export const QualityGateRunSchema = z.object({
   durationMs: z.number().int().nonnegative().optional(),
 })
 
+export const TerminationCauseSchema = z.enum([
+  'exit-clean',
+  'graceful',
+  'sigterm-timeout',
+  'sigkill-timeout',
+  'failed',
+  'killed-by-signal',
+])
+
 export const SessionSchema = z.object({
   id: z.string().min(1),
   projectId: z.string().min(1),
@@ -75,9 +84,15 @@ export const SessionSchema = z.object({
   endedAt: z.string().datetime().nullable(),
   costCents: z.number().int().nonnegative().nullable(),
   promptVersion: z.string().min(1),
+  modelUsed: z.string().nullable(),
   branchName: z.string().nullable(),
   prNumber: z.number().int().positive().nullable(),
+  prUrl: z.string().url().nullable(),
   journalPath: z.string().nullable(),
+  logPath: z.string().nullable(),
+  terminationCause: TerminationCauseSchema.nullable(),
+  isFixupTurn: z.boolean().default(false),
+  parentSessionId: z.string().min(1).nullable(),
 })
 
 export const SessionResultSchema = z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -14,8 +14,10 @@ import type {
   PullRequestSchema,
   CostRecordSchema,
   BriefingSchema,
+  TerminationCauseSchema,
 } from './schemas.js'
 import type { z } from 'zod'
+import type { PROJECT_STACKS } from './constants.js'
 
 // ─── Autonomy ────────────────────────────────────────────────────────
 
@@ -74,3 +76,19 @@ export type CostRecord = z.infer<typeof CostRecordSchema>
 // ─── Briefing ────────────────────────────────────────────────────────
 
 export type Briefing = z.infer<typeof BriefingSchema>
+
+// ─── Termination cause ───────────────────────────────────────────────
+
+export type TerminationCause = z.infer<typeof TerminationCauseSchema>
+
+// ─── Project stacks ──────────────────────────────────────────────────
+
+export type ProjectStack = (typeof PROJECT_STACKS)[number]
+
+export interface QualityGateCommand {
+  /** Argv-style: program plus args. Never a shell string. */
+  command: string
+  args: string[]
+  /** Where to run the command, relative to project root. */
+  cwd?: string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,27 @@ importers:
       '@maestro/api':
         specifier: workspace:*
         version: link:packages/api
+      '@maestro/conductor':
+        specifier: workspace:*
+        version: link:packages/conductor
       '@maestro/shared':
         specifier: workspace:*
         version: link:packages/shared
       cac:
         specifier: ^6.7.14
         version: 6.7.14
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      kleur:
+        specifier: ^4.1.5
+        version: 4.1.5
+      prompts:
+        specifier: ^2.4.2
+        version: 2.4.2
+      simple-git:
+        specifier: ^3.27.0
+        version: 3.36.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.18.0
@@ -24,6 +39,9 @@ importers:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
+      '@types/prompts':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.20.0
         version: 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
@@ -91,21 +109,36 @@ importers:
       '@maestro/shared':
         specifier: workspace:*
         version: link:../shared
+      '@octokit/rest':
+        specifier: ^21.1.0
+        version: 21.1.1
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
+      execa:
+        specifier: ^9.5.2
+        version: 9.6.1
       hono:
         specifier: ^4.6.14
         version: 4.12.15
+      p-retry:
+        specifier: ^6.2.1
+        version: 6.2.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.3
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
+      simple-git:
+        specifier: ^3.27.0
+        version: 3.36.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -116,6 +149,9 @@ importers:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -813,6 +849,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -824,6 +866,64 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@5.1.2':
+    resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@6.1.6':
+    resolution: {integrity: sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@10.1.4':
+    resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@8.2.2':
+    resolution: {integrity: sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/plugin-paginate-rest@11.6.0':
+    resolution: {integrity: sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@5.3.1':
+    resolution: {integrity: sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@13.5.0':
+    resolution: {integrity: sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@9.2.4':
+    resolution: {integrity: sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/rest@21.1.1':
+    resolution: {integrity: sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -960,6 +1060,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -984,8 +1097,14 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/prompts@2.4.9':
+    resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
 
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
@@ -994,6 +1113,12 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@typescript-eslint/eslint-plugin@8.59.1':
     resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
@@ -1188,6 +1313,9 @@ packages:
     resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  before-after-hook@3.0.2:
+    resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
   better-sqlite3@12.9.0:
     resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
@@ -1512,6 +1640,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -1519,6 +1651,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-content-type-parse@2.0.1:
+    resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
 
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
@@ -1550,6 +1685,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1618,6 +1757,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -1652,6 +1795,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -1685,6 +1831,10 @@ packages:
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1779,6 +1929,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -1786,6 +1940,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -1799,6 +1957,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -1810,6 +1972,10 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -1873,6 +2039,14 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1966,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2021,9 +2199,17 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2032,6 +2218,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -2145,11 +2335,22 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2240,6 +2441,14 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2333,11 +2542,24 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -2389,6 +2611,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -2529,6 +2755,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2698,6 +2931,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3151,6 +3388,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3162,6 +3407,74 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@octokit/auth-token@5.1.2': {}
+
+  '@octokit/core@6.1.6':
+    dependencies:
+      '@octokit/auth-token': 5.1.2
+      '@octokit/graphql': 8.2.2
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      before-after-hook: 3.0.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@10.1.4':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@8.2.2':
+    dependencies:
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/plugin-paginate-rest@11.6.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 13.10.0
+
+  '@octokit/plugin-request-log@5.3.1(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+
+  '@octokit/plugin-rest-endpoint-methods@13.5.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 13.10.0
+
+  '@octokit/request-error@6.1.8':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request@9.2.4':
+    dependencies:
+      '@octokit/endpoint': 10.1.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 2.0.1
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@21.1.1':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.6)
+      '@octokit/plugin-request-log': 5.3.1(@octokit/core@6.1.6)
+      '@octokit/plugin-rest-endpoint-methods': 13.5.0(@octokit/core@6.1.6)
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
 
   '@pinojs/redact@0.4.0': {}
 
@@ -3244,6 +3557,16 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.2
@@ -3277,7 +3600,16 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prompts@2.4.9':
+    dependencies:
+      '@types/node': 22.19.17
+      kleur: 3.0.3
+
   '@types/prop-types@15.7.15': {}
+
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
@@ -3287,6 +3619,10 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/retry@0.12.2': {}
+
+  '@types/retry@0.12.5': {}
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -3544,6 +3880,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.23: {}
+
+  before-after-hook@3.0.2: {}
 
   better-sqlite3@12.9.0:
     dependencies:
@@ -4048,9 +4386,26 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  fast-content-type-parse@2.0.1: {}
 
   fast-copy@4.0.3: {}
 
@@ -4077,6 +4432,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4148,6 +4507,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -4179,6 +4543,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -4204,6 +4570,8 @@ snapshots:
   help-me@5.0.0: {}
 
   hono@4.12.15: {}
+
+  human-signals@8.0.1: {}
 
   ieee754@1.2.1: {}
 
@@ -4296,12 +4664,16 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.1: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -4315,6 +4687,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -4330,6 +4704,8 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
+
+  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -4385,6 +4761,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   levn@0.4.1:
     dependencies:
@@ -4467,6 +4847,11 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -4534,13 +4919,23 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.3.1
+      retry: 0.13.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
 
+  parse-ms@4.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -4657,13 +5052,28 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   process-warning@5.0.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   pump@3.0.4:
     dependencies:
@@ -4766,6 +5176,10 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -4901,6 +5315,10 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -4908,6 +5326,18 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  sisteransi@1.0.5: {}
 
   sonic-boom@4.2.1:
     dependencies:
@@ -4983,6 +5413,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
 
@@ -5164,6 +5596,10 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicorn-magic@0.3.0: {}
+
+  universal-user-agent@7.0.3: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -5329,6 +5765,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod@3.25.76: {}
 

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -1,47 +1,122 @@
 #!/usr/bin/env tsx
-// `maestro` CLI. Lightweight wrapper around the conductor API for tasks the
-// developer runs from the terminal.
+// `maestro` CLI entry point.
 //
-// Phase 0: `list` and `status` hit the API. `add` and `run` are stubbed to
-// "not implemented" — the actual project registration and session triggering
-// arrive in Phases 1 and 2 respectively.
+// `init`, `add`, `run`, and `inspect` operate against the local SQLite
+// database (via the conductor's library API) so they work even when the
+// HTTP server isn't running.
+// `list` and `status` hit the running conductor over HTTP.
 
 import { cac } from 'cac'
 import type { HealthResponse, ListProjectsResponse } from '@maestro/api'
+import {
+  PROJECT_AUTONOMY_LEVELS,
+  QUALITY_GATE_NAMES,
+  type ProjectAutonomyConfig,
+} from '@maestro/shared'
+import { runInit } from './cli/init.js'
+import { runAdd } from './cli/add.js'
+import { runRun, runInspect } from './cli/run.js'
+import { failWith, loadEnvFromRepoRoot } from './cli/util.js'
+
+loadEnvFromRepoRoot()
 
 const PACKAGE_VERSION = '0.0.0'
-const DEFAULT_API_BASE = process.env.MAESTRO_API_BASE ?? 'http://localhost:3000'
+const DEFAULT_API_BASE = process.env['MAESTRO_API_BASE'] ?? 'http://localhost:3000'
 
 const cli = cac('maestro')
 
 cli
-  .command('add <repo-url>', 'Register a GitHub repository with Maestro')
-  .option('--autonomy <level>', 'Autonomy level (full|pr-only|draft-only|paused)', {
-    default: 'pr-only',
+  .command('init <project-path>', 'Interactive .maestro/ scaffolding for a project')
+  .option('--force', 'Skip the dirty-git-tree check')
+  .option('--non-interactive', 'Use defaults / flags instead of prompts (CI-friendly)')
+  .option('--focus <text>', 'Required with --non-interactive: 1–3 sentences for state.md')
+  .option('--task <text>', 'Repeatable: an entry under "Next Concrete Tasks"')
+  .option(
+    '--level <level>',
+    `Autonomy level (${PROJECT_AUTONOMY_LEVELS.join('|')})`,
+    { default: 'pr-only' },
+  )
+  .option('--schedule <cron>', 'Cron schedule string', { default: '0 */6 * * *' })
+  .option('--time-budget-minutes <n>', 'Session time budget in minutes', { default: 45 })
+  .option(
+    '--gates <list>',
+    `Comma-separated quality gates (${QUALITY_GATE_NAMES.join('|')})`,
+    { default: 'test,lint,typecheck' },
+  )
+  .option('--branch-prefix <prefix>', 'Branch prefix for Maestro PRs', {
+    default: 'maestro/',
   })
-  .option('--schedule <cron>', 'Cron schedule', { default: '0 */6 * * *' })
-  .action((_repoUrl: string, _opts: unknown) => {
-    notImplemented(
-      'maestro add',
-      'Project registration arrives in Phase 1. See PRODUCT_VISION.md.',
-    )
+  .action(
+    async (
+      path: string,
+      opts: {
+        force?: boolean
+        nonInteractive?: boolean
+        focus?: string
+        task?: string | string[]
+        level?: string
+        schedule?: string
+        timeBudgetMinutes?: number | string
+        gates?: string
+        branchPrefix?: string
+      },
+    ) => {
+      const tasks = Array.isArray(opts.task) ? opts.task : opts.task ? [opts.task] : []
+      const level = opts.level as ProjectAutonomyConfig['level']
+      if (!PROJECT_AUTONOMY_LEVELS.includes(level)) {
+        failWith(`Invalid --level: ${opts.level}`)
+      }
+      const gates = (opts.gates ?? '')
+        .split(',')
+        .map((g) => g.trim())
+        .filter(Boolean) as ProjectAutonomyConfig['qualityGates']
+      for (const g of gates) {
+        if (!QUALITY_GATE_NAMES.includes(g)) {
+          failWith(`Invalid --gates entry: ${g}`)
+        }
+      }
+      const minutes = Number(opts.timeBudgetMinutes ?? 45)
+      if (!Number.isFinite(minutes) || minutes < 5 || minutes > 180) {
+        failWith('--time-budget-minutes must be between 5 and 180')
+      }
+      await runInit(path, {
+        force: opts.force ?? false,
+        nonInteractive: opts.nonInteractive ?? false,
+        focus: opts.focus,
+        tasks,
+        level,
+        schedule: opts.schedule,
+        timeBudgetMinutes: minutes,
+        qualityGates: gates,
+        branchPrefix: opts.branchPrefix,
+      })
+    },
+  )
+
+cli
+  .command('add <repo-url>', 'Register a GitHub repository with Maestro')
+  .option('--from-path <path>', 'Use a local checkout instead of cloning the repo')
+  .action(async (repoUrl: string, opts: { fromPath?: string }) => {
+    await runAdd(repoUrl, { fromPath: opts.fromPath })
   })
 
 cli
-  .command('run <project>', 'Manually trigger a session for a project')
-  .option('--dry-run', 'Build the prompt and log it without spawning Claude')
-  .action((_project: string, _opts: { dryRun?: boolean }) => {
-    notImplemented(
-      'maestro run',
-      'Manual session execution arrives in Phase 1. See PRODUCT_VISION.md.',
-    )
+  .command('run <slug>', 'Manually trigger a session for a project')
+  .option('--dry-run', 'Build the prompt and log it without spawning Claude Code')
+  .option('--claude-bin <path>', 'Override the claude binary (test-only)')
+  .action(async (slug: string, opts: { dryRun?: boolean; claudeBin?: string }) => {
+    await runRun(slug, { dryRun: opts.dryRun ?? false, claudeBin: opts.claudeBin })
+  })
+
+cli
+  .command('inspect <session-id>', 'Show details and log tail for a session')
+  .action(async (sessionId: string) => {
+    await runInspect(sessionId)
   })
 
 cli
   .command('list', 'List projects under Maestro management')
-  .option('--api <url>', 'Override the conductor API base URL', {
-    default: DEFAULT_API_BASE,
-  })
+  .option('--api <url>', 'Override the conductor API base URL', { default: DEFAULT_API_BASE })
   .action(async (opts: { api: string }) => {
     const data = await fetchJson<ListProjectsResponse>(opts.api, '/api/projects')
     if (data.projects.length === 0) {
@@ -55,9 +130,7 @@ cli
 
 cli
   .command('status', 'Conductor health check')
-  .option('--api <url>', 'Override the conductor API base URL', {
-    default: DEFAULT_API_BASE,
-  })
+  .option('--api <url>', 'Override the conductor API base URL', { default: DEFAULT_API_BASE })
   .action(async (opts: { api: string }) => {
     const health = await fetchJson<HealthResponse>(opts.api, '/api/health')
     console.log(`status     ${health.status}`)
@@ -73,14 +146,7 @@ try {
   cli.parse(process.argv, { run: false })
   await cli.runMatchedCommand()
 } catch (err) {
-  console.error(err instanceof Error ? err.message : err)
-  process.exit(1)
-}
-
-function notImplemented(name: string, why: string): never {
-  console.error(`${name}: not implemented`)
-  console.error(why)
-  process.exit(2)
+  failWith(err instanceof Error ? err.message : String(err), err)
 }
 
 async function fetchJson<T>(base: string, path: string): Promise<T> {

--- a/scripts/cli/add.ts
+++ b/scripts/cli/add.ts
@@ -1,0 +1,94 @@
+// `maestro add <repo-url>` — register a project with the conductor.
+//
+// Clones the repo into a temp directory, validates `.maestro/` is present
+// and Zod-clean, parses autonomy.json, then inserts a row into the
+// projects table. The clone is removed on success — the worker will create
+// its own working clone under MAESTRO_DATA_DIR/work/<slug>.
+
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import simpleGit from 'simple-git'
+import {
+  loadConfig,
+  openDatabase,
+  ProjectRepository,
+  parseRepoUrl,
+  readMaestroDir,
+} from '@maestro/conductor'
+import { failWith, info, ok } from './util.js'
+
+interface AddOptions {
+  /**
+   * Use a local path instead of cloning. The path must already contain a
+   * valid `.maestro/`. Pair with --repo-url for what to record.
+   */
+  fromPath?: string
+}
+
+export async function runAdd(repoUrl: string, options: AddOptions = {}): Promise<void> {
+  const config = loadConfig()
+  const { db, close } = openDatabase({ dataDir: config.dataDir })
+  try {
+    const repo = parseRepoUrl(repoUrl)
+    const slug = `${repo.owner}-${repo.repo}`.toLowerCase()
+    const projects = new ProjectRepository(db)
+
+    if (projects.findBySlug(slug)) {
+      failWith(`Project ${slug} is already registered`)
+    }
+
+    const checkoutPath = options.fromPath
+      ? resolve(options.fromPath)
+      : await cloneToTemp(repoUrl)
+
+    try {
+      if (!existsSync(checkoutPath)) {
+        failWith(`Path does not exist: ${checkoutPath}`)
+      }
+      info(`validating .maestro/ in ${checkoutPath}`)
+      const maestro = await readMaestroDir(checkoutPath).catch((err) => {
+        failWith('.maestro/ is missing or invalid', err)
+      })
+      if (!maestro) failWith('readMaestroDir returned no value')
+
+      const project = projects.insert({
+        id: randomUUID(),
+        slug,
+        repoUrl,
+        autonomyConfig: maestro.autonomy,
+      })
+
+      ok(`registered ${project.slug}`)
+      console.log(`  level    : ${project.autonomyConfig.level}`)
+      console.log(`  schedule : ${project.autonomyConfig.schedule}`)
+      console.log(`  budget   : ${Math.round(project.autonomyConfig.timeBudget / 60)}m`)
+      console.log(`  gates    : ${project.autonomyConfig.qualityGates.join(', ')}`)
+      console.log()
+      console.log('Next steps:')
+      console.log(`  1. Dry-run a session:  maestro run ${project.slug} --dry-run`)
+      console.log(`  2. Real session:       maestro run ${project.slug}`)
+    } finally {
+      if (!options.fromPath) {
+        await rm(checkoutPath, { recursive: true, force: true })
+      }
+    }
+  } finally {
+    close()
+  }
+}
+
+async function cloneToTemp(repoUrl: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'maestro-add-'))
+  const checkoutPath = join(dir, 'checkout')
+  info(`cloning ${repoUrl} → ${checkoutPath}`)
+  try {
+    await simpleGit().clone(repoUrl, checkoutPath)
+    return checkoutPath
+  } catch (err) {
+    await rm(dir, { recursive: true, force: true })
+    failWith(`Failed to clone ${repoUrl}`, err)
+  }
+}

--- a/scripts/cli/init.ts
+++ b/scripts/cli/init.ts
@@ -1,0 +1,374 @@
+// `maestro init <project-path>` — interactive .maestro/ scaffolding.
+//
+// Validates the path is a clean git checkout, scrapes a starter context.md
+// from the project (package.json scripts, README excerpt, top-level dirs),
+// asks the developer for state.md focus + initial tasks and autonomy
+// settings, then writes the `.maestro/` skeleton.
+
+import { existsSync } from 'node:fs'
+import { readFile, readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import prompts from 'prompts'
+import simpleGit from 'simple-git'
+import {
+  AutonomyFileSchema,
+  DEFAULT_AUTONOMY_CONFIG,
+  DEFAULT_QUALITY_GATES,
+  DEFAULT_TIME_BUDGET_SECONDS,
+  PROJECT_AUTONOMY_LEVELS,
+  QUALITY_GATE_NAMES,
+  type ProjectAutonomyConfig,
+} from '@maestro/shared'
+import { initMaestroDir } from '@maestro/conductor'
+import { failWith, info, ok } from './util.js'
+
+export interface InitOptions {
+  /** When true, skip the dirty-git-tree check. Useful for tests. */
+  force?: boolean
+  /** When true, never prompt — caller must supply enough fields below. */
+  nonInteractive?: boolean
+  focus?: string
+  tasks?: string[]
+  level?: ProjectAutonomyConfig['level']
+  schedule?: string
+  timeBudgetMinutes?: number
+  qualityGates?: ProjectAutonomyConfig['qualityGates']
+  branchPrefix?: string
+}
+
+export async function runInit(rawPath: string, options: InitOptions = {}): Promise<void> {
+  const projectRoot = resolve(rawPath)
+  if (!existsSync(projectRoot)) failWith(`Path does not exist: ${projectRoot}`)
+
+  await ensureCleanGitRepo(projectRoot, options.force ?? false)
+
+  const seed = await scrapeContext(projectRoot)
+  const responses = options.nonInteractive
+    ? buildNonInteractiveResponses(options)
+    : await askInteractive(seed.name)
+  const stateBody = renderStateMd({
+    focus: responses.focus,
+    tasks: responses.tasks,
+  })
+  const autonomy = buildAutonomy(responses)
+
+  info(`writing .maestro/ to ${projectRoot}`)
+  try {
+    await initMaestroDir({
+      projectRoot,
+      state: stateBody,
+      context: seed.contextMd,
+      autonomy,
+    })
+  } catch (err) {
+    failWith('Failed to initialise .maestro/', err)
+  }
+
+  ok('.maestro/ created and validated')
+  console.log()
+  console.log('Next steps:')
+  console.log(`  1. Edit ${projectRoot}/.maestro/context.md to flesh out project context`)
+  console.log('  2. Commit .maestro/ to your project repo')
+  console.log('  3. Register with Maestro:  maestro add <repo-url>')
+  console.log('  4. Dry-run a session:      maestro run <slug> --dry-run')
+}
+
+// ─── Pre-flight ──────────────────────────────────────────────────────
+
+async function ensureCleanGitRepo(projectRoot: string, force: boolean): Promise<void> {
+  if (!existsSync(`${projectRoot}/.git`)) {
+    failWith(`${projectRoot} is not a git repository`)
+  }
+  if (force) return
+  const git = simpleGit(projectRoot)
+  const status = await git.status()
+  if (!status.isClean()) {
+    failWith(
+      `${projectRoot} has uncommitted changes. Stash, commit, or rerun with --force.`,
+      new Error(`modified=${status.modified.length} not_added=${status.not_added.length}`),
+    )
+  }
+}
+
+// ─── Context scraping ────────────────────────────────────────────────
+
+interface SeededContext {
+  name: string
+  contextMd: string
+}
+
+async function scrapeContext(projectRoot: string): Promise<SeededContext> {
+  const lines: string[] = []
+  let projectName = projectRoot.split('/').slice(-1)[0] ?? 'project'
+
+  const pkgPath = `${projectRoot}/package.json`
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8')) as {
+        name?: string
+        description?: string
+        scripts?: Record<string, string>
+        dependencies?: Record<string, string>
+        devDependencies?: Record<string, string>
+      }
+      if (pkg.name) projectName = pkg.name
+      lines.push(`# Project Context — ${projectName}`)
+      lines.push('')
+      lines.push('## Stack')
+      lines.push('')
+      lines.push('Detected from package.json. Update freely.')
+      if (pkg.description) {
+        lines.push('')
+        lines.push(`> ${pkg.description}`)
+      }
+      if (pkg.scripts) {
+        lines.push('')
+        lines.push('### Scripts')
+        lines.push('')
+        for (const [name, value] of Object.entries(pkg.scripts)) {
+          lines.push(`- \`${name}\`: \`${value}\``)
+        }
+      }
+      const deps = Object.keys({ ...pkg.dependencies, ...pkg.devDependencies })
+        .filter((d) => !d.startsWith('@types/'))
+        .slice(0, 12)
+      if (deps.length > 0) {
+        lines.push('')
+        lines.push('### Notable dependencies')
+        lines.push('')
+        lines.push(deps.map((d) => `- ${d}`).join('\n'))
+      }
+    } catch {
+      lines.push(`# Project Context — ${projectName}`)
+    }
+  } else if (existsSync(`${projectRoot}/pyproject.toml`)) {
+    lines.push(`# Project Context — ${projectName}`)
+    lines.push('')
+    lines.push('## Stack')
+    lines.push('')
+    lines.push('Python project (pyproject.toml). Fill in framework, deps, etc.')
+  } else if (existsSync(`${projectRoot}/Cargo.toml`)) {
+    lines.push(`# Project Context — ${projectName}`)
+    lines.push('')
+    lines.push('## Stack')
+    lines.push('')
+    lines.push('Rust project (Cargo.toml).')
+  } else {
+    lines.push(`# Project Context — ${projectName}`)
+    lines.push('')
+    lines.push('## Stack')
+    lines.push('')
+    lines.push('Unrecognised project layout. Describe it here.')
+  }
+
+  // Top-level layout
+  try {
+    const entries = (await readdir(projectRoot, { withFileTypes: true }))
+      .filter((e) => !e.name.startsWith('.') && e.name !== 'node_modules')
+      .slice(0, 20)
+    if (entries.length > 0) {
+      lines.push('')
+      lines.push('## Top-level layout')
+      lines.push('')
+      lines.push(
+        entries.map((e) => `- \`${e.name}${e.isDirectory() ? '/' : ''}\``).join('\n'),
+      )
+    }
+  } catch {
+    /* ignore */
+  }
+
+  // README excerpt
+  for (const candidate of ['README.md', 'README', 'Readme.md']) {
+    const p = `${projectRoot}/${candidate}`
+    if (existsSync(p)) {
+      try {
+        const body = await readFile(p, 'utf-8')
+        const excerpt = body.split('\n').slice(0, 30).join('\n').trim()
+        if (excerpt.length > 0) {
+          lines.push('')
+          lines.push('## README excerpt')
+          lines.push('')
+          lines.push(excerpt)
+        }
+      } catch {
+        /* ignore */
+      }
+      break
+    }
+  }
+
+  lines.push('')
+  lines.push('## Conventions')
+  lines.push('')
+  lines.push('- Code style: _fill in_')
+  lines.push('- Commit format: _fill in_')
+  lines.push('- Test patterns: _fill in_')
+  lines.push('')
+  lines.push('## Project-specific NEVER list')
+  lines.push('')
+  lines.push('_Add anything the agent must not touch without explicit state.md instruction._')
+
+  return { name: projectName, contextMd: lines.join('\n') + '\n' }
+}
+
+// ─── Interactive prompts ─────────────────────────────────────────────
+
+interface Responses {
+  focus: string
+  tasks: string[]
+  level: ProjectAutonomyConfig['level']
+  schedule: string
+  timeBudgetMinutes: number
+  qualityGates: ProjectAutonomyConfig['qualityGates']
+  branchPrefix: string
+}
+
+async function askInteractive(suggestedName: string): Promise<Responses> {
+  void suggestedName
+  const focus = await ask<string>({
+    type: 'text',
+    name: 'value',
+    message: 'Current focus (1–3 sentences)',
+    validate: (s) => (s.trim().length > 0 ? true : 'required'),
+  })
+
+  const tasksRaw = await ask<string>({
+    type: 'text',
+    name: 'value',
+    message: 'Initial tasks (one per line; blank line to finish)',
+    multiline: true,
+  })
+  const tasks = tasksRaw
+    .split('\n')
+    .map((t) => t.trim())
+    .filter(Boolean)
+
+  const level = await ask<ProjectAutonomyConfig['level']>({
+    type: 'select',
+    name: 'value',
+    message: 'Autonomy level',
+    initial: 1,
+    choices: PROJECT_AUTONOMY_LEVELS.map((l) => ({ title: l, value: l })),
+  })
+
+  const schedule = await ask<string>({
+    type: 'text',
+    name: 'value',
+    message: 'Cron schedule (Phase 2 will read this)',
+    initial: DEFAULT_AUTONOMY_CONFIG.schedule,
+  })
+
+  const timeBudgetMinutes = await ask<number>({
+    type: 'number',
+    name: 'value',
+    message: 'Time budget per session (minutes)',
+    initial: DEFAULT_TIME_BUDGET_SECONDS / 60,
+    min: 5,
+    max: 180,
+  })
+
+  const qualityGates = await ask<ProjectAutonomyConfig['qualityGates']>({
+    type: 'multiselect',
+    name: 'value',
+    message: 'Quality gates to run pre-PR',
+    instructions: false,
+    choices: QUALITY_GATE_NAMES.map((g) => ({
+      title: g,
+      value: g,
+      selected: DEFAULT_QUALITY_GATES.includes(g),
+    })),
+  })
+
+  const branchPrefix = await ask<string>({
+    type: 'text',
+    name: 'value',
+    message: 'Branch prefix for Maestro PRs',
+    initial: 'maestro/',
+  })
+
+  return {
+    focus,
+    tasks,
+    level,
+    schedule,
+    timeBudgetMinutes,
+    qualityGates,
+    branchPrefix,
+  }
+}
+
+async function ask<T>(question: prompts.PromptObject): Promise<T> {
+  const answer = await prompts(question, {
+    onCancel: () => {
+      console.log('\nCancelled.')
+      process.exit(130)
+    },
+  })
+  return answer['value'] as T
+}
+
+function buildNonInteractiveResponses(o: InitOptions): Responses {
+  if (!o.focus || o.focus.trim().length === 0) {
+    failWith('--non-interactive requires --focus "<sentence>"')
+  }
+  return {
+    focus: o.focus,
+    tasks: o.tasks ?? [],
+    level: o.level ?? 'pr-only',
+    schedule: o.schedule ?? DEFAULT_AUTONOMY_CONFIG.schedule,
+    timeBudgetMinutes: o.timeBudgetMinutes ?? DEFAULT_TIME_BUDGET_SECONDS / 60,
+    qualityGates: o.qualityGates ?? DEFAULT_QUALITY_GATES,
+    branchPrefix: o.branchPrefix ?? 'maestro/',
+  }
+}
+
+// ─── Composition ─────────────────────────────────────────────────────
+
+function renderStateMd(args: { focus: string; tasks: string[] }): string {
+  const taskLines =
+    args.tasks.length > 0
+      ? args.tasks.map((t) => `- [ ] ${t}`).join('\n')
+      : '- [ ] _add 3-5 concrete tasks here_'
+  return [
+    '# Current State',
+    '',
+    '## Focus',
+    args.focus.trim(),
+    '',
+    '## Next Concrete Tasks',
+    taskLines,
+    '',
+    '## Blockers',
+    '',
+    '_(none)_',
+    '',
+    '## Recent Context',
+    '',
+    'Project initialised by `maestro init`. The first session is for orientation only.',
+    '',
+    '## Notes',
+    '',
+    '',
+  ].join('\n')
+}
+
+function buildAutonomy(r: Responses): ProjectAutonomyConfig {
+  const draft = {
+    level: r.level,
+    schedule: r.schedule,
+    timeBudget: Math.round(r.timeBudgetMinutes * 60),
+    qualityGates: r.qualityGates,
+    branches: {
+      base: 'main',
+      prefix: r.branchPrefix.endsWith('/') ? r.branchPrefix : `${r.branchPrefix}/`,
+    },
+    github: {
+      prLabels: ['maestro'],
+      draftByDefault: r.level === 'draft-only',
+    },
+    skipDays: [],
+    maxSessionsPerDay: 6,
+  }
+  return AutonomyFileSchema.parse(draft)
+}

--- a/scripts/cli/run.ts
+++ b/scripts/cli/run.ts
@@ -1,0 +1,114 @@
+// `maestro run <slug>` and `maestro inspect <session-id>`. Both talk to
+// the local SQLite via the conductor's library API rather than going
+// through the HTTP server, so the CLI works even when the conductor isn't
+// running.
+
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import {
+  loadConfig,
+  openDatabase,
+  ProjectRepository,
+  QualityGateRepository,
+  SessionRepository,
+  runSession,
+} from '@maestro/conductor'
+import { failWith, info, ok, pretty, warn } from './util.js'
+
+export interface RunOptions {
+  dryRun?: boolean
+  /** Override the claude binary; intended for tests, not normal use. */
+  claudeBin?: string
+}
+
+export async function runRun(slug: string, options: RunOptions): Promise<void> {
+  const config = loadConfig()
+  const { db, close } = openDatabase({ dataDir: config.dataDir })
+  try {
+    const projects = new ProjectRepository(db)
+    const project = projects.findBySlug(slug)
+    if (!project) failWith(`Unknown project slug: ${slug}`)
+
+    info(`session for ${project.slug}${options.dryRun ? ' (dry run)' : ''}`)
+    info(`time budget: ${Math.round(project.autonomyConfig.timeBudget / 60)}m`)
+
+    const result = await runSession({
+      db,
+      config,
+      project,
+      dryRun: options.dryRun ?? false,
+      claudeBin: options.claudeBin,
+    })
+
+    if (options.dryRun) {
+      ok('dry-run prompt printed above')
+      return
+    }
+
+    ok(`session ${result.sessionId} → ${result.status}`)
+    if (result.branchName) console.log(pretty('branch', result.branchName))
+    if (result.prNumber !== null) console.log(pretty('PR #', String(result.prNumber)))
+    if (result.notes) console.log(pretty('notes', result.notes))
+    if (result.qualityGates.length > 0) {
+      console.log()
+      console.log('Quality gates:')
+      for (const g of result.qualityGates) {
+        const tag = g.status === 'passed' ? '✓' : g.status === 'failed' ? '✗' : '∼'
+        console.log(`  ${tag} ${g.gateName}`)
+      }
+    }
+    console.log()
+    console.log(`log: ${result.logPath}`)
+    if (result.fixupTurnRan) warn('a fixup turn ran (see logs)')
+  } finally {
+    close()
+  }
+}
+
+export async function runInspect(sessionId: string): Promise<void> {
+  const config = loadConfig()
+  const { db, close } = openDatabase({ dataDir: config.dataDir })
+  try {
+    const sessions = new SessionRepository(db)
+    const gates = new QualityGateRepository(db)
+    const session = sessions.findById(sessionId)
+    if (!session) failWith(`Unknown session: ${sessionId}`)
+
+    console.log(pretty('id', session.id))
+    console.log(pretty('project', session.projectId))
+    console.log(pretty('status', session.status))
+    console.log(pretty('started', session.startedAt))
+    console.log(pretty('ended', session.endedAt))
+    console.log(pretty('branch', session.branchName))
+    console.log(pretty('PR #', session.prNumber !== null ? String(session.prNumber) : null))
+    console.log(pretty('PR url', session.prUrl))
+    console.log(pretty('cost (¢)', session.costCents !== null ? String(session.costCents) : null))
+    console.log(pretty('model', session.modelUsed))
+    console.log(pretty('terminated', session.terminationCause))
+    console.log(pretty('log', session.logPath))
+    console.log(pretty('journal', session.journalPath))
+
+    const gateRows = gates.listForSession(session.id)
+    if (gateRows.length > 0) {
+      console.log()
+      console.log('Quality gates:')
+      for (const g of gateRows) {
+        console.log(`  ${tagFor(g.status)} ${g.gateName}${g.durationMs ? `  (${Math.round(g.durationMs / 1000)}s)` : ''}`)
+      }
+    }
+
+    if (session.logPath && existsSync(session.logPath)) {
+      console.log()
+      console.log('--- log tail ---')
+      const text = await readFile(session.logPath, 'utf-8')
+      const lines = text.split('\n')
+      console.log(lines.slice(-200).join('\n'))
+    }
+  } finally {
+    close()
+  }
+}
+
+function tagFor(s: string): string {
+  return s === 'passed' ? '✓' : s === 'failed' ? '✗' : '∼'
+}

--- a/scripts/cli/util.ts
+++ b/scripts/cli/util.ts
@@ -1,0 +1,68 @@
+// Helpers shared by the CLI subcommands. Centralises DB opening, env
+// loading, and pretty error printing so each command focuses on its own
+// flow.
+
+import 'dotenv/config'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { config as loadDotenv } from 'dotenv'
+import kleur from 'kleur'
+import { isMaestroError } from '@maestro/shared'
+
+export function loadEnvFromRepoRoot(): void {
+  let dir = process.cwd()
+  for (let i = 0; i < 8; i++) {
+    const candidate = resolve(dir, '.env')
+    if (existsSync(candidate)) {
+      loadDotenv({ path: candidate })
+      return
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return
+    dir = parent
+  }
+}
+
+export function failWith(message: string, err?: unknown): never {
+  console.error(kleur.red(`× ${message}`))
+  if (err) {
+    if (isMaestroError(err)) {
+      console.error(kleur.red(`  code: ${err.code}`))
+      if (err.message && err.message !== message) {
+        console.error(kleur.red(`  ${err.message}`))
+      }
+      if (Object.keys(err.context).length > 0) {
+        console.error(kleur.gray(`  context: ${JSON.stringify(err.context)}`))
+      }
+    } else if (err instanceof Error) {
+      console.error(kleur.gray(`  ${err.message}`))
+    } else {
+      console.error(kleur.gray(`  ${String(err)}`))
+    }
+  }
+  process.exit(1)
+}
+
+export function ok(message: string): void {
+  console.log(kleur.green(`✓ ${message}`))
+}
+
+export function info(message: string): void {
+  console.log(kleur.cyan(`→ ${message}`))
+}
+
+export function warn(message: string): void {
+  console.warn(kleur.yellow(`! ${message}`))
+}
+
+export function pretty(label: string, value: string | number | null | undefined): string {
+  return `${kleur.gray(label.padEnd(14))} ${value ?? kleur.gray('—')}`
+}
+
+export function expectEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    failWith(`Missing environment variable ${name}. See .env.example.`)
+  }
+  return value
+}


### PR DESCRIPTION
## Summary
- Worker pipeline (worker.ts) implements the 12-step session flow end-to-end: lock → clone → read .maestro/ → build prompt → spawn `claude` → time-budget kill → verify state writes → quality gates → optional fixup → PR/needs-review label → persist row.
- New conductor modules: `claude-runner`, `quality-gates`, `pr-manager`, `state-manager`, `stack-detector`, `locks`, `repositories`, `lib` (programmatic API barrel), and SQL migration `002_phase1_session_columns`.
- CLI rewrite: `init` / `add` / `run` (with `--dry-run`) / `inspect`. `init` accepts `--non-interactive` + flags for CI use.
- Dashboard real data: Overview, Sessions list, Session detail (gates + log tail).
- API endpoints: `/api/projects`, `/api/sessions`, `/api/sessions/:id`, `/api/sessions/:id/log`.
- Tests: env-driven `mock-claude.mjs`, prompt golden-file, worker integration (happy / failed-gate / lock contention).
- DECISIONS.md → ADRs 11–14 (Claude CLI flags, SQLite locks, fixup retry, env whitelist).
- Verification fixes bundled (bin shim, absolute working dirs, fixupTurnRan reporting, eslint + gitignore).

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm build` succeeds across all four packages
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` zero warnings (`--max-warnings=0`)
- [x] `pnpm test` — 6/6 passing (golden + 3 worker integration)
- [x] End-to-end smoke verified on github.com/aaryansinha16/maestro-test (PR #1 there shipped, fixed the seeded bug)

Closes #13