### PR TITLE
[#18] feat(shared,db): scheduling schema, types, repositories

### DIFF
--- a/packages/conductor/src/db/migrations/003_phase2_scheduling.sql
+++ b/packages/conductor/src/db/migrations/003_phase2_scheduling.sql
@@ -1,0 +1,58 @@
+-- Phase 2 scheduling schema.
+--
+-- Adds the columns and tables that the scheduler, job queue, and skip
+-- rules need. No behaviour lives here yet — that lands in subsequent PRs.
+-- Existing rows in `projects` get scheduled_enabled = 0 by default, so
+-- enabling Phase 2 cannot accidentally start firing sessions on a real
+-- project the developer hasn't explicitly opted in (per umbrella issue
+-- #17 hard requirement).
+
+ALTER TABLE projects ADD COLUMN scheduled_enabled INTEGER NOT NULL DEFAULT 0
+  CHECK (scheduled_enabled IN (0, 1));
+ALTER TABLE projects ADD COLUMN auto_paused_at   TEXT;
+ALTER TABLE projects ADD COLUMN auto_pause_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_projects_scheduled_enabled
+  ON projects(scheduled_enabled);
+
+-- Persistent backing store for the in-memory JobQueue. On startup the
+-- conductor marks any rows still in `running` as `cancelled` with reason
+-- 'conductor-restart' so a crash doesn't leave a stuck slot.
+CREATE TABLE IF NOT EXISTS job_queue (
+  id           TEXT PRIMARY KEY,
+  project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  source       TEXT NOT NULL CHECK (source IN ('schedule', 'manual', 'retry')),
+  priority     INTEGER NOT NULL DEFAULT 0, -- higher = jumps queue
+  status       TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled'))
+                 DEFAULT 'queued',
+  enqueued_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  started_at   TEXT,
+  ended_at     TEXT,
+  session_id   TEXT,
+  cancel_reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_queue_status_priority_enqueued
+  ON job_queue(status, priority DESC, enqueued_at ASC);
+CREATE INDEX IF NOT EXISTS idx_job_queue_project_status
+  ON job_queue(project_id, status);
+
+-- The audit log behind "why didn't Maestro fire this morning?". One row
+-- per cron tick, regardless of whether it produced a job. The `action`
+-- column distinguishes "fired and queued" from "fired but skipped" from
+-- "tried to fire but the schedule registration failed".
+CREATE TABLE IF NOT EXISTS scheduled_runs (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  scheduled_at  TEXT NOT NULL,
+  fired_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  action        TEXT NOT NULL CHECK (action IN ('enqueued', 'skipped', 'failed-to-fire')),
+  skip_reason   TEXT,
+  job_id        TEXT REFERENCES job_queue(id) ON DELETE SET NULL,
+  notes         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_runs_project_fired
+  ON scheduled_runs(project_id, fired_at DESC);
+CREATE INDEX IF NOT EXISTS idx_scheduled_runs_action
+  ON scheduled_runs(action);

--- a/packages/conductor/src/repositories.ts
+++ b/packages/conductor/src/repositories.ts
@@ -8,6 +8,8 @@ import {
   ProjectSchema,
   SessionSchema,
   QualityGateRunSchema,
+  JobSchema,
+  ScheduledRunSchema,
   type Project,
   type ProjectAutonomyConfig,
   type Session,
@@ -16,6 +18,12 @@ import {
   type QualityGateRun,
   type QualityGate,
   type QualityGateStatus,
+  type Job,
+  type JobSource,
+  type JobStatus,
+  type ScheduledRun,
+  type ScheduledRunAction,
+  type ScheduleSkipReason,
   MaestroError,
 } from '@maestro/shared'
 
@@ -27,6 +35,10 @@ interface ProjectRow {
   repo_url: string
   autonomy_config_json: string
   created_at: string
+  // Phase 2 — added by migration 003.
+  scheduled_enabled: number
+  auto_paused_at: string | null
+  auto_pause_reason: string | null
 }
 
 export interface CreateProjectInput {
@@ -40,12 +52,23 @@ export class ProjectRepository {
   constructor(private readonly db: Database.Database) {}
 
   insert(input: CreateProjectInput): Project {
+    // The autonomy.json controls scheduledEnabled at the file level; the
+    // row column mirrors it. Phase 2 ships every existing/new project at
+    // scheduledEnabled=false (umbrella #17 hard requirement) so the
+    // developer enables scheduling explicitly per project.
+    const scheduledEnabled = input.autonomyConfig.scheduledEnabled ? 1 : 0
     const stmt = this.db.prepare(`
-      INSERT INTO projects (id, slug, repo_url, autonomy_config_json)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO projects (id, slug, repo_url, autonomy_config_json, scheduled_enabled)
+      VALUES (?, ?, ?, ?, ?)
     `)
     try {
-      stmt.run(input.id, input.slug, input.repoUrl, JSON.stringify(input.autonomyConfig))
+      stmt.run(
+        input.id,
+        input.slug,
+        input.repoUrl,
+        JSON.stringify(input.autonomyConfig),
+        scheduledEnabled,
+      )
     } catch (err) {
       throw new MaestroError('CONFIG_VALIDATION_FAILED', {
         message: `Failed to insert project ${input.slug}`,
@@ -79,6 +102,54 @@ export class ProjectRepository {
     return rows.map(rowToProject)
   }
 
+  /**
+   * Phase 2: list only projects with scheduling enabled and not in an
+   * auto-pause state. The scheduler reads this every poll cycle.
+   */
+  listSchedulable(): Project[] {
+    const rows = this.db
+      .prepare<[], ProjectRow>(
+        `SELECT * FROM projects WHERE scheduled_enabled = 1 AND auto_paused_at IS NULL`,
+      )
+      .all()
+    return rows.map(rowToProject)
+  }
+
+  setScheduledEnabled(slug: string, enabled: boolean): void {
+    this.db
+      .prepare('UPDATE projects SET scheduled_enabled = ? WHERE slug = ?')
+      .run(enabled ? 1 : 0, slug)
+  }
+
+  /**
+   * Persist a config edit (e.g. schedule string change, priority bump).
+   * Mirrors the autonomy.json file but only at the row level — the file
+   * itself lives in the managed repo and is the source of truth (ADR-004).
+   */
+  updateAutonomyConfig(slug: string, config: ProjectAutonomyConfig): void {
+    this.db
+      .prepare(
+        'UPDATE projects SET autonomy_config_json = ?, scheduled_enabled = ? WHERE slug = ?',
+      )
+      .run(JSON.stringify(config), config.scheduledEnabled ? 1 : 0, slug)
+  }
+
+  setAutoPause(slug: string, reason: string): void {
+    this.db
+      .prepare(
+        'UPDATE projects SET auto_paused_at = strftime(\'%Y-%m-%dT%H:%M:%fZ\',\'now\'), auto_pause_reason = ? WHERE slug = ?',
+      )
+      .run(reason, slug)
+  }
+
+  clearAutoPause(slug: string): void {
+    this.db
+      .prepare(
+        'UPDATE projects SET auto_paused_at = NULL, auto_pause_reason = NULL WHERE slug = ?',
+      )
+      .run(slug)
+  }
+
   delete(slug: string): void {
     this.db.prepare('DELETE FROM projects WHERE slug = ?').run(slug)
   }
@@ -91,6 +162,9 @@ function rowToProject(row: ProjectRow): Project {
     repoUrl: row.repo_url,
     autonomyConfig: JSON.parse(row.autonomy_config_json) as unknown,
     createdAt: row.created_at,
+    scheduledEnabled: row.scheduled_enabled === 1,
+    autoPausedAt: row.auto_paused_at,
+    autoPauseReason: row.auto_pause_reason,
   })
 }
 
@@ -414,4 +488,279 @@ export class QualityGateRepository {
       }),
     )
   }
+}
+
+// ─── Phase 2: job queue ──────────────────────────────────────────────
+
+interface JobRow {
+  id: string
+  project_id: string
+  source: JobSource
+  priority: number
+  status: JobStatus
+  enqueued_at: string
+  started_at: string | null
+  ended_at: string | null
+  session_id: string | null
+  cancel_reason: string | null
+}
+
+export interface CreateJobInput {
+  id: string
+  projectId: string
+  source: JobSource
+  priority: number
+}
+
+export interface UpdateJobInput {
+  status?: JobStatus
+  startedAt?: string | null
+  endedAt?: string | null
+  sessionId?: string | null
+  cancelReason?: string | null
+}
+
+export class JobQueueRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: CreateJobInput): Job {
+    this.db
+      .prepare(
+        `INSERT INTO job_queue (id, project_id, source, priority, status)
+         VALUES (?, ?, ?, ?, 'queued')`,
+      )
+      .run(input.id, input.projectId, input.source, input.priority)
+    const row = this.findById(input.id)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'job insert lost' })
+    return row
+  }
+
+  findById(id: string): Job | null {
+    const row = this.db
+      .prepare<[string], JobRow>('SELECT * FROM job_queue WHERE id = ?')
+      .get(id)
+    return row ? rowToJob(row) : null
+  }
+
+  /**
+   * Job-queue ordering: status='queued' first, then by priority DESC,
+   * then by enqueued_at ASC (FIFO within priority class). The scheduler
+   * iterates this and picks the next eligible job.
+   */
+  listQueued(): Job[] {
+    const rows = this.db
+      .prepare<[], JobRow>(
+        `SELECT * FROM job_queue WHERE status = 'queued'
+         ORDER BY priority DESC, enqueued_at ASC`,
+      )
+      .all()
+    return rows.map(rowToJob)
+  }
+
+  listRunning(): Job[] {
+    const rows = this.db
+      .prepare<[], JobRow>(`SELECT * FROM job_queue WHERE status = 'running'`)
+      .all()
+    return rows.map(rowToJob)
+  }
+
+  /** Sessions completed in the last `since` ms — used by the dashboard. */
+  listRecent(since: Date): Job[] {
+    const rows = this.db
+      .prepare<[string], JobRow>(
+        `SELECT * FROM job_queue
+         WHERE ended_at IS NOT NULL AND ended_at >= ?
+         ORDER BY ended_at DESC`,
+      )
+      .all(since.toISOString())
+    return rows.map(rowToJob)
+  }
+
+  countQueuedForProject(projectId: string): number {
+    return (
+      this.db
+        .prepare<[string], { c: number }>(
+          `SELECT COUNT(*) AS c FROM job_queue WHERE project_id = ? AND status = 'queued'`,
+        )
+        .get(projectId) as { c: number }
+    ).c
+  }
+
+  hasRunningForProject(projectId: string): boolean {
+    return (
+      (
+        this.db
+          .prepare<[string], { c: number }>(
+            `SELECT COUNT(*) AS c FROM job_queue WHERE project_id = ? AND status = 'running'`,
+          )
+          .get(projectId) as { c: number }
+      ).c > 0
+    )
+  }
+
+  update(id: string, patch: UpdateJobInput): Job {
+    const setParts: string[] = []
+    const values: Array<string | null> = []
+    const map: Record<string, keyof UpdateJobInput> = {
+      status: 'status',
+      started_at: 'startedAt',
+      ended_at: 'endedAt',
+      session_id: 'sessionId',
+      cancel_reason: 'cancelReason',
+    }
+    for (const column of Object.keys(map)) {
+      const key = map[column]
+      if (key === undefined) continue
+      const value = patch[key]
+      if (value === undefined) continue
+      setParts.push(`${column} = ?`)
+      values.push(value)
+    }
+    if (setParts.length === 0) {
+      const existing = this.findById(id)
+      if (!existing) throw new MaestroError('INTERNAL_ERROR', { message: `job ${id} missing` })
+      return existing
+    }
+    values.push(id)
+    this.db.prepare(`UPDATE job_queue SET ${setParts.join(', ')} WHERE id = ?`).run(...values)
+    const row = this.findById(id)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: `job ${id} missing after update` })
+    return row
+  }
+
+  /**
+   * Crash recovery: any rows still in 'running' from a previous boot are
+   * orphaned. Mark them cancelled with reason 'conductor-restart' so a
+   * fresh boot doesn't think those slots are still occupied.
+   * Returns the number of jobs reclaimed.
+   */
+  cancelStaleOnBoot(): number {
+    const result = this.db
+      .prepare(
+        `UPDATE job_queue
+           SET status = 'cancelled',
+               ended_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+               cancel_reason = 'conductor-restart'
+         WHERE status = 'running'`,
+      )
+      .run()
+    return result.changes
+  }
+}
+
+function rowToJob(row: JobRow): Job {
+  return JobSchema.parse({
+    id: row.id,
+    projectId: row.project_id,
+    source: row.source,
+    status: row.status,
+    priority: row.priority,
+    enqueuedAt: row.enqueued_at,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    sessionId: row.session_id,
+    cancelReason: row.cancel_reason,
+  })
+}
+
+// ─── Phase 2: scheduled-runs audit log ───────────────────────────────
+
+interface ScheduledRunRow {
+  id: number
+  project_id: string
+  scheduled_at: string
+  fired_at: string
+  action: ScheduledRunAction
+  skip_reason: ScheduleSkipReason | null
+  job_id: string | null
+  notes: string | null
+}
+
+export interface RecordScheduledRunInput {
+  projectId: string
+  scheduledAt: string
+  action: ScheduledRunAction
+  skipReason?: ScheduleSkipReason | null
+  jobId?: string | null
+  notes?: string | null
+}
+
+export class ScheduledRunsRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: RecordScheduledRunInput): ScheduledRun {
+    this.db
+      .prepare(
+        `INSERT INTO scheduled_runs (project_id, scheduled_at, action, skip_reason, job_id, notes)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.projectId,
+        input.scheduledAt,
+        input.action,
+        input.skipReason ?? null,
+        input.jobId ?? null,
+        input.notes ?? null,
+      )
+    const row = this.db
+      .prepare<[], ScheduledRunRow>('SELECT * FROM scheduled_runs ORDER BY id DESC LIMIT 1')
+      .get()
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'scheduled_runs insert lost' })
+    return rowToScheduledRun(row)
+  }
+
+  recentForProject(projectId: string, limit = 20): ScheduledRun[] {
+    const rows = this.db
+      .prepare<[string, number], ScheduledRunRow>(
+        `SELECT * FROM scheduled_runs WHERE project_id = ?
+         ORDER BY fired_at DESC LIMIT ?`,
+      )
+      .all(projectId, limit)
+    return rows.map(rowToScheduledRun)
+  }
+
+  /**
+   * Counts of {scheduled, ran, skipped} from today (UTC) — feeds the
+   * dashboard Overview stats card.
+   */
+  todaySummary(): { scheduled: number; enqueued: number; skipped: number } {
+    const todayStart = new Date()
+    todayStart.setUTCHours(0, 0, 0, 0)
+    const since = todayStart.toISOString()
+    const total = (
+      this.db
+        .prepare<[string], { c: number }>(
+          `SELECT COUNT(*) AS c FROM scheduled_runs WHERE fired_at >= ?`,
+        )
+        .get(since) as { c: number }
+    ).c
+    const enqueued = (
+      this.db
+        .prepare<[string], { c: number }>(
+          `SELECT COUNT(*) AS c FROM scheduled_runs WHERE fired_at >= ? AND action = 'enqueued'`,
+        )
+        .get(since) as { c: number }
+    ).c
+    const skipped = (
+      this.db
+        .prepare<[string], { c: number }>(
+          `SELECT COUNT(*) AS c FROM scheduled_runs WHERE fired_at >= ? AND action = 'skipped'`,
+        )
+        .get(since) as { c: number }
+    ).c
+    return { scheduled: total, enqueued, skipped }
+  }
+}
+
+function rowToScheduledRun(row: ScheduledRunRow): ScheduledRun {
+  return ScheduledRunSchema.parse({
+    id: row.id,
+    projectId: row.project_id,
+    scheduledAt: row.scheduled_at,
+    firedAt: row.fired_at,
+    action: row.action,
+    skipReason: row.skip_reason,
+    jobId: row.job_id,
+    notes: row.notes,
+  })
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -48,6 +48,10 @@ export const DEFAULT_AUTONOMY_CONFIG: ProjectAutonomyConfig = {
   },
   skipDays: [],
   maxSessionsPerDay: 6,
+  // Phase 2: scheduling is opt-in. Defaults to false; the developer
+  // enables per project after manual sessions prove the project is healthy.
+  scheduledEnabled: false,
+  priority: 'normal',
 }
 
 // ─── Scheduling ──────────────────────────────────────────────────────
@@ -129,3 +133,44 @@ export const DEFAULT_MONTHLY_BUDGET_USD = 50
 // Threshold (fraction of monthly budget) at which the dashboard surfaces a
 // "approaching budget" alert.
 export const COST_WARN_BUDGET_FRACTION = 0.8
+
+// ─── Phase 2: scheduling ─────────────────────────────────────────────
+
+// Default global parallel-session ceiling. Overridable via
+// MAESTRO_MAX_PARALLEL env var. Per-project concurrency is always 1
+// (ADR-008) and enforced separately by the project_locks table.
+export const DEFAULT_MAX_PARALLEL = 2
+
+// How often the scheduler polls the projects table for hot-reload.
+// 30 s is a pragmatic compromise — fast enough that schedule edits
+// take effect mid-day without a restart, slow enough to be cheap.
+export const SCHEDULER_POLL_INTERVAL_MS = 30_000
+
+// Default window the "developer recently active" skip rule looks at.
+// Overridable via MAESTRO_DEVELOPER_ACTIVITY_WINDOW_HOURS.
+export const DEFAULT_DEVELOPER_ACTIVITY_WINDOW_HOURS = 4
+
+// Cost throttle thresholds (fraction of monthly budget). Above LOW,
+// `priority: low` projects are skipped. Above ALL, every scheduled run
+// is skipped (manual triggers still work).
+export const COST_THROTTLE_LOW_FRACTION = 0.8
+export const COST_THROTTLE_ALL_FRACTION = 0.95
+
+// Failed-session backoff: a project's nth scheduled run is skipped when
+// the consecutive_failures counter reaches FAILURE_BACKOFF_THRESHOLD.
+// We skip (count - threshold + 1) runs then try again.
+export const FAILURE_BACKOFF_THRESHOLD = 3
+
+// Auto-pause kicks in at this many consecutive failures. Distinct from
+// the backoff threshold so the developer has a clear "stop scheduling"
+// signal, with manual triggers still available.
+export const AUTO_PAUSE_FAILURE_THRESHOLD = 5
+
+// Manual triggers always have higher priority than scheduled ones.
+// Higher number = jumps queue earlier.
+export const JOB_PRIORITY_SCHEDULED = 0
+export const JOB_PRIORITY_MANUAL = 100
+export const JOB_PRIORITY_RETRY = 50
+
+// Default polling interval for the dashboard /queue page.
+export const QUEUE_POLL_INTERVAL_MS = 5_000

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -14,6 +14,22 @@ export const QualityGateNameSchema = z.enum(['test', 'lint', 'typecheck', 'build
 
 export const QualityGateStatusSchema = z.enum(['passed', 'failed', 'skipped'])
 
+// Phase 2: priority hints used by the cost-throttling skip rule. `low`
+// projects skip first when the monthly budget runs hot.
+export const ProjectPrioritySchema = z.enum(['high', 'normal', 'low'])
+
+// Phase 2: weekday names accepted in autonomy.json `skipDays`. Stored
+// case-insensitively; normalised to lowercase by the scheduler.
+export const WeekdaySchema = z.enum([
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+])
+
 export const ProjectAutonomyConfigSchema = z.object({
   level: ProjectAutonomyLevelSchema,
   // Standard cron expression. Validated as a non-empty string here; the
@@ -30,8 +46,14 @@ export const ProjectAutonomyConfigSchema = z.object({
     prLabels: z.array(z.string()).default([]),
     draftByDefault: z.boolean().default(false),
   }),
-  skipDays: z.array(z.string()).default([]),
+  skipDays: z.array(WeekdaySchema).default([]),
   maxSessionsPerDay: z.number().int().positive().default(6),
+  // Phase 2: scheduled execution is opt-in per project. Defaults to
+  // false so a project added via `maestro add` only fires from manual
+  // triggers until the developer enables it explicitly. See ADR-020+.
+  scheduledEnabled: z.boolean().default(false),
+  // Phase 2: cost-throttling priority hint. See skip rule E.
+  priority: ProjectPrioritySchema.default('normal'),
 })
 
 // ─── Project ─────────────────────────────────────────────────────────
@@ -42,6 +64,13 @@ export const ProjectSchema = z.object({
   repoUrl: z.string().url(),
   autonomyConfig: ProjectAutonomyConfigSchema,
   createdAt: z.string().datetime(),
+  // Phase 2: row-level scheduling state. `scheduledEnabled` is the
+  // canonical "is scheduling on?" flag at the row level, mirroring the
+  // autonomy.json field for fast queries. autoPausedAt is set when the
+  // failure-tracker decides a project shouldn't auto-fire any more.
+  scheduledEnabled: z.boolean().default(false),
+  autoPausedAt: z.string().datetime().nullable().default(null),
+  autoPauseReason: z.string().nullable().default(null),
 })
 
 // ─── Sessions & quality gates ────────────────────────────────────────
@@ -191,3 +220,59 @@ export const BriefingSchema = z.object({
 // content as ProjectAutonomyConfigSchema; isolated alias so we can evolve the
 // on-disk format separately from the in-memory representation if needed.
 export const AutonomyFileSchema = ProjectAutonomyConfigSchema
+
+// ─── Phase 2: job queue + scheduled runs ─────────────────────────────
+
+export const JobSourceSchema = z.enum(['schedule', 'manual', 'retry'])
+export const JobStatusSchema = z.enum([
+  'queued',
+  'running',
+  'completed',
+  'failed',
+  'cancelled',
+])
+
+export const JobSchema = z.object({
+  id: z.string().min(1),
+  projectId: z.string().min(1),
+  source: JobSourceSchema,
+  status: JobStatusSchema,
+  priority: z.number().int(),
+  enqueuedAt: z.string().datetime(),
+  startedAt: z.string().datetime().nullable(),
+  endedAt: z.string().datetime().nullable(),
+  sessionId: z.string().min(1).nullable(),
+  cancelReason: z.string().nullable(),
+})
+
+export const ScheduledRunActionSchema = z.enum([
+  'enqueued',
+  'skipped',
+  'failed-to-fire',
+])
+
+// Typed reasons the scheduler may record on a `skipped` row. Encoded as
+// strings so the audit log is human-readable in SQLite without a join.
+export const ScheduleSkipReasonSchema = z.enum([
+  'developer-recently-active',
+  'max-sessions-per-day',
+  'skip-day',
+  'auto-paused',
+  'manual-paused',
+  'cost-throttle-low-priority',
+  'cost-throttle-budget-exceeded',
+  'failure-backoff',
+  'project-disabled',
+  'unknown',
+])
+
+export const ScheduledRunSchema = z.object({
+  id: z.number().int(),
+  projectId: z.string().min(1),
+  scheduledAt: z.string().datetime(),
+  firedAt: z.string().datetime(),
+  action: ScheduledRunActionSchema,
+  skipReason: ScheduleSkipReasonSchema.nullable(),
+  jobId: z.string().nullable(),
+  notes: z.string().nullable(),
+})

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -15,6 +15,14 @@ import type {
   CostRecordSchema,
   BriefingSchema,
   TerminationCauseSchema,
+  ProjectPrioritySchema,
+  WeekdaySchema,
+  JobSchema,
+  JobSourceSchema,
+  JobStatusSchema,
+  ScheduledRunSchema,
+  ScheduledRunActionSchema,
+  ScheduleSkipReasonSchema,
 } from './schemas.js'
 import type { z } from 'zod'
 import type { PROJECT_STACKS } from './constants.js'
@@ -92,3 +100,26 @@ export interface QualityGateCommand {
   /** Where to run the command, relative to project root. */
   cwd?: string
 }
+
+// ─── Phase 2: scheduling + queue ─────────────────────────────────────
+
+export type ProjectPriority = z.infer<typeof ProjectPrioritySchema>
+
+export const WEEKDAYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const
+export type Weekday = z.infer<typeof WeekdaySchema>
+
+export type JobSource = z.infer<typeof JobSourceSchema>
+export type JobStatus = z.infer<typeof JobStatusSchema>
+export type Job = z.infer<typeof JobSchema>
+
+export type ScheduledRunAction = z.infer<typeof ScheduledRunActionSchema>
+export type ScheduleSkipReason = z.infer<typeof ScheduleSkipReasonSchema>
+export type ScheduledRun = z.infer<typeof ScheduledRunSchema>


### PR DESCRIPTION
## Summary
- Migration `003_phase2_scheduling.sql` adds `scheduled_enabled` / `auto_paused_at` / `auto_pause_reason` to `projects`, plus new `job_queue` and `scheduled_runs` tables.
- `ProjectAutonomyConfigSchema` gains `scheduledEnabled` (default `false`) and `priority` ('high'|'normal'|'low'). `WeekdaySchema` typifies `skipDays`. `ProjectSchema` adds the three row columns.
- New `JobSchema`, `JobSourceSchema`, `JobStatusSchema`, `ScheduledRunSchema`, `ScheduledRunActionSchema`, `ScheduleSkipReasonSchema`.
- `JobQueueRepository` + `ScheduledRunsRepository` land with crash-recovery (`cancelStaleOnBoot`) and audit-log (`todaySummary`) helpers.
- `ProjectRepository` learns `setScheduledEnabled`, `updateAutonomyConfig`, `setAutoPause`, `clearAutoPause`, `listSchedulable`.
- New constants: `DEFAULT_MAX_PARALLEL`, `SCHEDULER_POLL_INTERVAL_MS`, threshold/fraction constants for cost throttling and auto-pause.

## Hard requirement
Existing/new projects default to `scheduled_enabled = 0`, so this PR cannot accidentally start firing scheduled sessions on a real project. Subsequent PRs in the umbrella build on this without changing that default.

## Test plan
- [x] `pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm test` — all pass; 24/24 existing tests still green
- [x] Conductor boot smoke test: migration 003 applies cleanly on a fresh DB; `job_queue` / `scheduled_runs` tables present; `projects` schema shows the new columns

Part of #17. Closes #18.