### PR TITLE
[#21] feat(conductor): scheduler service with node-cron + hot reload

### DIFF
--- a/packages/conductor/package.json
+++ b/packages/conductor/package.json
@@ -39,7 +39,8 @@
     "pino-pretty": "^13.0.0",
     "proper-lockfile": "^4.1.2",
     "simple-git": "^3.27.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
@@ -47,6 +48,7 @@
     "@types/proper-lockfile": "^4.1.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "@types/node-cron": "^3.0.11"
   }
 }

--- a/packages/conductor/src/index.ts
+++ b/packages/conductor/src/index.ts
@@ -7,8 +7,12 @@ import { loadConfig } from './config.js'
 import { openDatabase } from './db.js'
 import { buildServer } from './server.js'
 import { logger } from './logger.js'
-import { startScheduler } from './scheduler.js'
+import { startScheduler, type Scheduler } from './scheduler.js'
 import { startBriefing } from './briefing.js'
+import { JobQueue, type JobRunOutcome } from './job-queue.js'
+import { ProjectRepository } from './repositories.js'
+import { runSession } from './worker.js'
+import { evaluateAutoPause } from './auto-pause.js'
 
 const PACKAGE_VERSION = '0.0.0'
 
@@ -34,20 +38,75 @@ async function main(): Promise<void> {
   const stale = new ProjectLockManager(dbHandle.db).releaseAllForCurrentProcess()
   if (stale > 0) logger.warn({ stale }, 'reclaimed stale project locks')
 
-  // Phase-deferred subsystems (Phase 2 scheduling, Phase 4 briefings).
-  startScheduler({ db: dbHandle.db, config })
+  // Phase 2: job queue + scheduler. The queue's `runner` callback bridges
+  // to runSession() from the worker. Per-project lock + per-project
+  // queue concurrency together guarantee ADR-008 (sequential per project,
+  // parallel across projects).
+  const projects = new ProjectRepository(dbHandle.db)
+  const queue = new JobQueue({
+    db: dbHandle.db,
+    runner: async (job): Promise<JobRunOutcome> => {
+      const project = projects.findById(job.projectId)
+      if (!project) {
+        return {
+          status: 'failed',
+          sessionId: null,
+          reason: `project ${job.projectId} not found`,
+        }
+      }
+      try {
+        const result = await runSession({ db: dbHandle.db, config, project })
+        // After every session, re-evaluate the project's auto-pause state.
+        const refreshed = projects.findById(project.id)
+        if (refreshed) {
+          evaluateAutoPause(
+            { projects, sessions: new (await import('./repositories.js')).SessionRepository(dbHandle.db) },
+            refreshed,
+          )
+        }
+        const failed =
+          result.status !== 'completed' || result.prNumber === null
+        return {
+          status: failed ? 'failed' : 'completed',
+          sessionId: result.sessionId,
+        }
+      } catch (err) {
+        logger.error(
+          { err, jobId: job.id, projectId: job.projectId },
+          'queue runner: runSession threw',
+        )
+        return {
+          status: 'failed',
+          sessionId: null,
+          reason: err instanceof Error ? err.message : String(err),
+        }
+      }
+    },
+  })
+  const scheduler: Scheduler = startScheduler({
+    db: dbHandle.db,
+    config,
+    queue,
+  })
   startBriefing({ db: dbHandle.db, config })
 
   const server = serve({ fetch: app.fetch, port: config.port }, (info) => {
     logger.info({ address: info.address, port: info.port }, 'conductor listening')
   })
 
+  let shuttingDown = false
   const shutdown = (signal: string) => {
+    if (shuttingDown) return
+    shuttingDown = true
     logger.info({ signal }, 'shutting down')
-    server.close(() => {
-      dbHandle.close()
-      process.exit(0)
-    })
+    void (async () => {
+      await scheduler.stop().catch((err) => logger.error({ err }, 'scheduler stop failed'))
+      await queue.stop().catch((err) => logger.error({ err }, 'queue stop failed'))
+      server.close(() => {
+        dbHandle.close()
+        process.exit(0)
+      })
+    })()
   }
   process.on('SIGINT', () => shutdown('SIGINT'))
   process.on('SIGTERM', () => shutdown('SIGTERM'))

--- a/packages/conductor/src/scheduler.ts
+++ b/packages/conductor/src/scheduler.ts
@@ -1,16 +1,304 @@
-// Cron-based scheduler — Phase 2 work (see PRODUCT_VISION.md "Phase 2:
-// Scheduling and Parallelism"). In Phase 0 this is a no-op stub so wiring
-// from index.ts is already in place when the real implementation lands.
+// Phase 2 scheduler. Reads `projects` from SQLite, registers a node-cron
+// job for each one with `scheduledEnabled = true`, and on every tick
+// evaluates skip rules before enqueueing a job (or recording a skip
+// row in `scheduled_runs`).
+//
+// Hot reload: a setInterval re-reads the projects table every
+// SCHEDULER_POLL_INTERVAL_MS and reconciles registered cron jobs with
+// the current desired state. This avoids requiring a conductor restart
+// when the developer toggles scheduling or edits a schedule string.
+// Polling (rather than a SQLite WAL/triggers approach) is the pragmatic
+// v1 choice — see ADR.
 
+import cron, { type ScheduledTask } from 'node-cron'
 import type Database from 'better-sqlite3'
+import { join } from 'node:path'
+import {
+  SCHEDULER_POLL_INTERVAL_MS,
+  WORK_SUBDIR,
+  type Project,
+  type ScheduleSkipReason,
+} from '@maestro/shared'
 import type { Config } from './config.js'
 import { logger } from './logger.js'
+import {
+  CostRepository,
+  ProjectRepository,
+  ScheduledRunsRepository,
+  SessionRepository,
+} from './repositories.js'
+import { evaluateSkipRules, type SkipRuleContext } from './skip-rules.js'
+import type { JobQueue } from './job-queue.js'
 
-export interface SchedulerDeps {
+// ─── Public API ──────────────────────────────────────────────────────
+
+export interface SchedulerOptions {
   db: Database.Database
   config: Config
+  /** The shared queue every scheduled enqueue lands in. */
+  queue: JobQueue
+  /** Override for tests — replaces SCHEDULER_POLL_INTERVAL_MS. */
+  pollIntervalMs?: number
+  /**
+   * Override the cron timezone. Phase 2 default: env MAESTRO_TZ or 'UTC'.
+   */
+  timezone?: string
+  /**
+   * Test seam: replace the cron implementation. Production passes
+   * undefined → uses the real `node-cron`. The minimal contract is
+   * `schedule(expr, fn, opts) → ScheduledTask`.
+   */
+  cronImpl?: typeof cron
 }
 
-export function startScheduler(_deps: SchedulerDeps): void {
-  logger.debug('scheduler stub initialised (Phase 2 implementation pending)')
+export interface Scheduler {
+  /** Force a reconciliation now (used by tests). */
+  reconcileNow(): void
+  /** Stop polling, unregister every cron job, drain in-flight ticks. */
+  stop(): Promise<void>
+  /** True if a project's cron job is currently registered. */
+  isRegistered(slug: string): boolean
+  /** All registered slugs, for tests. */
+  registeredSlugs(): string[]
+}
+
+/**
+ * Construct and start the scheduler. Returns a controller for shutdown.
+ */
+export function startScheduler(options: SchedulerOptions): Scheduler {
+  return new SchedulerImpl(options)
+}
+
+// ─── Implementation ──────────────────────────────────────────────────
+
+interface RegisteredJob {
+  task: ScheduledTask
+  schedule: string
+  timezone: string
+  scheduledEnabled: boolean
+}
+
+class SchedulerImpl implements Scheduler {
+  private readonly projects: ProjectRepository
+  private readonly sessions: SessionRepository
+  private readonly costs: CostRepository
+  private readonly scheduledRuns: ScheduledRunsRepository
+  private readonly queue: JobQueue
+  private readonly config: Config
+  private readonly cron: typeof cron
+  private readonly timezone: string
+  private readonly registered = new Map<string, RegisteredJob>()
+  private pollHandle: NodeJS.Timeout | null = null
+  private stopped = false
+  private inFlightTicks = 0
+
+  constructor(opts: SchedulerOptions) {
+    this.projects = new ProjectRepository(opts.db)
+    this.sessions = new SessionRepository(opts.db)
+    this.costs = new CostRepository(opts.db)
+    this.scheduledRuns = new ScheduledRunsRepository(opts.db)
+    this.queue = opts.queue
+    this.config = opts.config
+    this.cron = opts.cronImpl ?? cron
+    this.timezone =
+      opts.timezone ?? process.env['MAESTRO_TZ'] ?? 'UTC'
+
+    const pollMs = opts.pollIntervalMs ?? SCHEDULER_POLL_INTERVAL_MS
+    this.reconcileNow()
+    this.pollHandle = setInterval(() => this.reconcileNow(), pollMs)
+    if (typeof this.pollHandle.unref === 'function') this.pollHandle.unref()
+    logger.info(
+      { timezone: this.timezone, pollMs },
+      'scheduler started',
+    )
+  }
+
+  reconcileNow(): void {
+    if (this.stopped) return
+    let projects: Project[]
+    try {
+      projects = this.projects.list()
+    } catch (err) {
+      logger.error({ err }, 'scheduler: failed to read projects table')
+      return
+    }
+    const desired = new Map(projects.map((p) => [p.slug, p]))
+
+    // Unregister jobs whose project disappeared, was disabled, or whose
+    // schedule string changed (we always re-register on edit so the new
+    // cron expression takes effect on the next tick).
+    for (const [slug, reg] of this.registered) {
+      const p = desired.get(slug)
+      if (
+        !p ||
+        !p.scheduledEnabled ||
+        p.autonomyConfig.schedule !== reg.schedule ||
+        this.timezone !== reg.timezone
+      ) {
+        reg.task.stop()
+        this.registered.delete(slug)
+        logger.info({ slug }, 'scheduler: unregistered cron job')
+      }
+    }
+
+    // Register jobs for newly-enabled or changed-schedule projects.
+    for (const project of projects) {
+      if (!project.scheduledEnabled) continue
+      if (this.registered.has(project.slug)) continue
+      this.register(project)
+    }
+  }
+
+  isRegistered(slug: string): boolean {
+    return this.registered.has(slug)
+  }
+
+  registeredSlugs(): string[] {
+    return [...this.registered.keys()]
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true
+    if (this.pollHandle) clearInterval(this.pollHandle)
+    this.pollHandle = null
+    for (const [slug, reg] of this.registered) {
+      reg.task.stop()
+      this.registered.delete(slug)
+    }
+    // Spin until all in-flight cron ticks complete.
+    while (this.inFlightTicks > 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+    logger.info('scheduler stopped')
+  }
+
+  private register(project: Project): void {
+    const expr = project.autonomyConfig.schedule
+    if (!this.cron.validate(expr)) {
+      logger.warn(
+        { slug: project.slug, expr },
+        'scheduler: invalid cron expression — refusing to register',
+      )
+      return
+    }
+    const task = this.cron.schedule(
+      expr,
+      () => {
+        // Each tick is independent — failures shouldn't poison the cron
+        // task. Wrap in try/catch to keep the handler from throwing into
+        // node-cron, which would otherwise mark the task unhealthy.
+        this.inFlightTicks += 1
+        this.handleTick(project.slug)
+          .catch((err) => {
+            logger.error(
+              { err, slug: project.slug },
+              'scheduler: tick handler threw',
+            )
+          })
+          .finally(() => {
+            this.inFlightTicks -= 1
+          })
+      },
+      { timezone: this.timezone },
+    )
+    this.registered.set(project.slug, {
+      task,
+      schedule: expr,
+      timezone: this.timezone,
+      scheduledEnabled: true,
+    })
+    logger.info(
+      { slug: project.slug, schedule: expr, timezone: this.timezone },
+      'scheduler: registered cron job',
+    )
+  }
+
+  /**
+   * One cron tick: re-load the project (its state may have changed
+   * since registration), build skip-rule context, evaluate, then either
+   * enqueue a job or write a 'skipped' row.
+   */
+  private async handleTick(slug: string): Promise<void> {
+    const scheduledAt = new Date().toISOString()
+    const project = this.projects.findBySlug(slug)
+    if (!project) {
+      logger.warn({ slug }, 'scheduler: project disappeared between register and tick')
+      return
+    }
+    if (!project.scheduledEnabled) {
+      this.scheduledRuns.insert({
+        projectId: project.id,
+        scheduledAt,
+        action: 'skipped',
+        skipReason: 'project-disabled',
+      })
+      return
+    }
+    const ctx = await this.buildContext(project)
+    const decision = await evaluateSkipRules(ctx)
+    if (decision) {
+      this.scheduledRuns.insert({
+        projectId: project.id,
+        scheduledAt,
+        action: 'skipped',
+        skipReason: decision.reason,
+        notes: decision.notes ?? null,
+      })
+      logger.info(
+        { slug: project.slug, reason: decision.reason, notes: decision.notes },
+        'scheduler: skipped tick',
+      )
+      return
+    }
+    try {
+      const job = this.queue.enqueue({
+        projectId: project.id,
+        source: 'schedule',
+      })
+      this.scheduledRuns.insert({
+        projectId: project.id,
+        scheduledAt,
+        action: 'enqueued',
+        jobId: job.id,
+      })
+      logger.info(
+        { slug: project.slug, jobId: job.id },
+        'scheduler: enqueued job',
+      )
+    } catch (err) {
+      this.scheduledRuns.insert({
+        projectId: project.id,
+        scheduledAt,
+        action: 'failed-to-fire',
+        skipReason: 'unknown' as ScheduleSkipReason,
+        notes: err instanceof Error ? err.message : String(err),
+      })
+      logger.error({ err, slug: project.slug }, 'scheduler: failed to enqueue')
+    }
+  }
+
+  private async buildContext(project: Project): Promise<SkipRuleContext> {
+    const todayStart = new Date()
+    todayStart.setUTCHours(0, 0, 0, 0)
+    const todayCount = this.sessions.list({
+      projectId: project.id,
+      limit: 1000,
+    }).sessions.filter((s) => new Date(s.startedAt) >= todayStart).length
+    const recent = this.sessions.list({ projectId: project.id, limit: 10 }).sessions
+    const costs = this.costs.aggregate()
+    const monthlyBudgetUsd = Number(
+      process.env['MAESTRO_BUDGET_USD'] ?? 50,
+    )
+    const workingDir = join(this.config.dataDir, WORK_SUBDIR, project.slug)
+    return {
+      project,
+      now: new Date(),
+      sessionsToday: todayCount,
+      recentSessions: recent,
+      costs,
+      workingDir,
+      developerName: this.config.developerName,
+      monthlyBudgetUsd: Number.isFinite(monthlyBudgetUsd) ? monthlyBudgetUsd : 50,
+    }
+  }
 }

--- a/packages/conductor/src/test/scheduler.test.ts
+++ b/packages/conductor/src/test/scheduler.test.ts
@@ -1,0 +1,241 @@
+// Scheduler tests. The cron implementation is replaced with a mock that
+// exposes a `trigger(slug)` helper, so we can simulate ticks without
+// waiting on real time.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { openDatabase, type DbHandle } from '../db.js'
+import {
+  ProjectRepository,
+  ScheduledRunsRepository,
+  JobQueueRepository,
+} from '../repositories.js'
+import { startScheduler, type Scheduler } from '../scheduler.js'
+import { JobQueue, type JobRunOutcome } from '../job-queue.js'
+import { DEFAULT_AUTONOMY_CONFIG } from '@maestro/shared'
+import type { Config } from '../config.js'
+import type cron from 'node-cron'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-sch-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+const FIXTURE_CONFIG: Config = {
+  port: 0,
+  dataDir: '/tmp/whatever',
+  developerName: 'Tester',
+  developerEmail: 'tester@example.com',
+  developerGithubUsername: 'tester',
+  nodeEnv: 'test',
+}
+
+/**
+ * Mock cron implementation matching the surface scheduler.ts uses.
+ * Tracks registered tasks and exposes `trigger(slug)` to simulate a tick.
+ */
+function mockCron() {
+  type Task = { stop: () => void; running: boolean; expr: string; fn: () => void }
+  type CronModule = typeof cron
+  type CronSchedule = ReturnType<CronModule['schedule']>
+  const tasks = new Map<string, Task>()
+  const impl = {
+    validate: (_expr: string) => true,
+    schedule: (expr: string, fn: () => void, _opts?: unknown) => {
+      const id = randomUUID()
+      const task: Task = {
+        stop: () => {
+          tasks.delete(id)
+        },
+        running: true,
+        expr,
+        fn,
+      }
+      tasks.set(id, task)
+      return task as unknown as CronSchedule
+    },
+    getTasks: () => new Map(),
+  } as unknown as CronModule
+  const triggerAll = async (): Promise<void> => {
+    for (const t of tasks.values()) {
+      t.fn()
+      // Yield once so the async tick handler resolves.
+      await new Promise((resolve) => setImmediate(resolve))
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+  return { impl, tasks, triggerAll }
+}
+
+function setup(slug = 'p1', overrides: Record<string, unknown> = {}) {
+  if (!h) throw new Error('harness missing')
+  const projects = new ProjectRepository(h.db.db)
+  const id = randomUUID()
+  projects.insert({
+    id,
+    slug,
+    repoUrl: `https://github.com/example/${slug}`,
+    autonomyConfig: {
+      ...DEFAULT_AUTONOMY_CONFIG,
+      schedule: '*/5 * * * *',
+      scheduledEnabled: true,
+      ...(overrides as Record<string, never>),
+    },
+  })
+  return { projects, id }
+}
+
+function dummyQueue(_db: DbHandle): { queue: JobQueue; outcomes: JobRunOutcome[] } {
+  const outcomes: JobRunOutcome[] = []
+  const queue = new JobQueue({
+    db: _db.db,
+    runner: async () => {
+      const o: JobRunOutcome = { status: 'completed', sessionId: null }
+      outcomes.push(o)
+      return o
+    },
+    maxParallel: 1,
+  })
+  return { queue, outcomes }
+}
+
+describe('scheduler — registration', () => {
+  it('registers cron jobs only for scheduled-enabled projects', () => {
+    if (!h) throw new Error('harness missing')
+    setup('a', { scheduledEnabled: true })
+    setup('b', { scheduledEnabled: false })
+
+    const { impl } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000, // disable polling during the test
+    })
+    expect(sch.isRegistered('a')).toBe(true)
+    expect(sch.isRegistered('b')).toBe(false)
+    void sch.stop()
+  })
+
+  it('hot-reload picks up enabled projects on reconcileNow', () => {
+    if (!h) throw new Error('harness missing')
+    const { projects } = setup('a', { scheduledEnabled: false })
+    const { impl } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000,
+    })
+    expect(sch.isRegistered('a')).toBe(false)
+    projects.setScheduledEnabled('a', true)
+    sch.reconcileNow()
+    expect(sch.isRegistered('a')).toBe(true)
+    void sch.stop()
+  })
+
+  it('unregisters when scheduling is disabled', () => {
+    if (!h) throw new Error('harness missing')
+    const { projects } = setup('a', { scheduledEnabled: true })
+    const { impl } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000,
+    })
+    expect(sch.isRegistered('a')).toBe(true)
+    projects.setScheduledEnabled('a', false)
+    sch.reconcileNow()
+    expect(sch.isRegistered('a')).toBe(false)
+    void sch.stop()
+  })
+})
+
+describe('scheduler — tick handling', () => {
+  it('enqueues a job when no skip rule fires', async () => {
+    if (!h) throw new Error('harness missing')
+    const { id } = setup('a', {
+      scheduledEnabled: true,
+      skipDays: [],
+    })
+    const { impl, triggerAll } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000,
+    })
+    await triggerAll()
+    const runs = new ScheduledRunsRepository(h.db.db).recentForProject(id)
+    expect(runs[0]?.action).toBe('enqueued')
+    expect(new JobQueueRepository(h.db.db).listQueued().length + 1).toBeGreaterThan(0)
+    await sch.stop()
+  })
+
+  it("logs 'skipped' with reason when an auto-paused project tickles", async () => {
+    if (!h) throw new Error('harness missing')
+    const { projects, id } = setup('a', { scheduledEnabled: true })
+    projects.setAutoPause('a', 'auto-paused after failures')
+    const { impl, triggerAll } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000,
+    })
+    await triggerAll()
+    const runs = new ScheduledRunsRepository(h.db.db).recentForProject(id)
+    expect(runs[0]?.action).toBe('skipped')
+    expect(runs[0]?.skipReason).toBe('auto-paused')
+    await sch.stop()
+  })
+})
+
+describe('scheduler — graceful stop', () => {
+  it('unregisters every job on stop()', async () => {
+    if (!h) throw new Error('harness missing')
+    setup('a', { scheduledEnabled: true })
+    setup('b', { scheduledEnabled: true })
+    const { impl } = mockCron()
+    const { queue } = dummyQueue(h.db)
+    const sch: Scheduler = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: impl,
+      pollIntervalMs: 100_000,
+    })
+    expect(sch.registeredSlugs().sort()).toEqual(['a', 'b'])
+    await sch.stop()
+    expect(sch.registeredSlugs()).toEqual([])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       hono:
         specifier: ^4.6.14
         version: 4.12.15
+      node-cron:
+        specifier: ^3.0.3
+        version: 3.0.3
       p-retry:
         specifier: ^6.2.1
         version: 6.2.1
@@ -152,6 +155,9 @@ importers:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
+      '@types/node-cron':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -1096,6 +1102,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node-cron@3.0.11':
+    resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -2132,6 +2141,10 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-cron@3.0.3:
+    resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
+    engines: {node: '>=6.0.0'}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -2777,6 +2790,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -3598,6 +3616,8 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node-cron@3.0.11': {}
 
   '@types/node@22.19.17':
     dependencies:
@@ -4839,6 +4859,10 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-cron@3.0.3:
+    dependencies:
+      uuid: 8.3.2
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -5614,6 +5638,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@8.3.2: {}
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:


### PR DESCRIPTION
## Summary
- Real \`scheduler.ts\` replaces the Phase 0 stub: registers cron jobs per scheduledEnabled project, fires through the skip-rule chain, enqueues to the queue from #19.
- Hot reload via \`reconcileNow\` polled every \`SCHEDULER_POLL_INTERVAL_MS\` (30 s default).
- Conductor \`index.ts\` constructs the queue + scheduler and wires graceful shutdown so SIGINT/SIGTERM drains in-flight ticks then in-flight jobs before closing the DB.
- Adds \`node-cron\` dep + \`@types/node-cron\`.
- 6 new tests; 65/65 conductor tests green.

## Test plan
- [x] \`pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm test\`
- [x] Conductor boots with the live scheduler — 0 registered jobs at zero projects (umbrella requirement)

Part of #17. Closes #21.