### PR TITLE
[#23] feat(dashboard): Schedule + Queue pages, ProjectDetail panel

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -7,6 +7,8 @@ import { SessionDetail } from './pages/SessionDetail'
 import { PRs } from './pages/PRs'
 import { Settings } from './pages/Settings'
 import { Costs } from './pages/Costs'
+import { Schedule } from './pages/Schedule'
+import { Queue } from './pages/Queue'
 
 export function App() {
   return (
@@ -17,6 +19,8 @@ export function App() {
         <Route path="sessions" element={<Sessions />} />
         <Route path="sessions/:id" element={<SessionDetail />} />
         <Route path="prs" element={<PRs />} />
+        <Route path="schedule" element={<Schedule />} />
+        <Route path="queue" element={<Queue />} />
         <Route path="costs" element={<Costs />} />
         <Route path="settings" element={<Settings />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -14,6 +14,8 @@ const NAV: NavItem[] = [
   { to: '/', label: 'Overview', exact: true },
   { to: '/sessions', label: 'Sessions' },
   { to: '/prs', label: 'Pull Requests' },
+  { to: '/schedule', label: 'Schedule' },
+  { to: '/queue', label: 'Queue' },
   { to: '/costs', label: 'Costs' },
   { to: '/settings', label: 'Settings' },
 ]

--- a/packages/dashboard/src/pages/ProjectDetail.tsx
+++ b/packages/dashboard/src/pages/ProjectDetail.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import type {
   GetProjectResponse,
+  ListScheduleResponse,
   ListSessionsResponse,
+  ListSkipsResponse,
   CostAggregationsResponse,
 } from '@maestro/api'
 import { useApi } from '../hooks/useApi'
@@ -131,6 +133,8 @@ export function ProjectDetail() {
         )}
       </div>
 
+      <SchedulingPanel slug={p.slug} />
+
       <div className="panel">
         <header className="panel-header">
           <h3 className="font-medium text-white">Configuration</h3>
@@ -201,5 +205,94 @@ function ErrorCard({ message }: { message: string }) {
         {message}
       </div>
     </section>
+  )
+}
+
+function SchedulingPanel({ slug }: { slug: string }) {
+  const api = useApi()
+  const [schedule, setSchedule] = useState<ListScheduleResponse | null>(null)
+  const [skips, setSkips] = useState<ListSkipsResponse | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void Promise.all([
+      api.get<ListScheduleResponse>('/api/schedule'),
+      api.get<ListSkipsResponse>(`/api/projects/${encodeURIComponent(slug)}/skips?limit=10`),
+    ])
+      .then(([s, sk]) => {
+        if (cancelled) return
+        setSchedule(s)
+        setSkips(sk)
+      })
+      .catch(() => {
+        /* ignore — section is informational */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api, slug])
+  const entry = schedule?.entries.find((e) => e.slug === slug)
+
+  const resume = async () => {
+    await api.post(`/api/projects/${encodeURIComponent(slug)}/resume`)
+    const next = await api.get<ListScheduleResponse>('/api/schedule')
+    setSchedule(next)
+  }
+
+  return (
+    <div className="panel">
+      <header className="panel-header">
+        <h3 className="font-medium text-white">Scheduling</h3>
+        {entry?.autoPausedAt ? (
+          <button
+            onClick={() => void resume()}
+            className="text-xs text-amber-400 hover:underline"
+          >
+            resume now
+          </button>
+        ) : null}
+      </header>
+      <div className="grid grid-cols-1 gap-3 px-5 py-4 text-sm md:grid-cols-3">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-navy-400">Enabled</div>
+          <div className="text-navy-100">{entry?.scheduledEnabled ? 'yes' : 'no'}</div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-navy-400">Schedule</div>
+          <div className="font-mono text-navy-100">{entry?.schedule ?? '—'}</div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-navy-400">Next run</div>
+          <div className="text-navy-100">
+            {entry?.scheduledEnabled
+              ? entry?.nextRunAt
+                ? new Date(entry.nextRunAt).toLocaleString()
+                : '—'
+              : '—'}
+          </div>
+        </div>
+        {entry?.autoPausedAt ? (
+          <div className="md:col-span-3">
+            <div className="text-xs uppercase tracking-wide text-amber-500">Auto-paused</div>
+            <div className="text-amber-300">{entry.autoPauseReason ?? '(no reason)'}</div>
+          </div>
+        ) : null}
+      </div>
+      <header className="panel-header">
+        <h4 className="text-xs uppercase tracking-wide text-navy-400">Recent skips</h4>
+      </header>
+      <div className="px-5 py-3 text-xs text-navy-300">
+        {!skips || skips.skips.length === 0
+          ? '(none yet)'
+          : skips.skips.map((s) => (
+              <div key={s.id} className="flex justify-between border-b border-navy-700/50 py-1">
+                <span>
+                  <span className="font-mono">{s.action}</span>
+                  {s.skipReason ? <span className="ml-2">{s.skipReason}</span> : null}
+                </span>
+                <span className="text-navy-400">{new Date(s.firedAt).toLocaleString()}</span>
+              </div>
+            ))}
+      </div>
+    </div>
   )
 }

--- a/packages/dashboard/src/pages/Queue.tsx
+++ b/packages/dashboard/src/pages/Queue.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { QueueResponse } from '@maestro/api'
+import { useApi } from '../hooks/useApi'
+import { formatDateTime, formatDuration } from '../lib/format'
+
+const POLL_MS = 5_000
+
+export function Queue() {
+  const api = useApi()
+  const [data, setData] = useState<QueueResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchOnce = () => {
+      void api
+        .get<QueueResponse>('/api/queue')
+        .then((res) => {
+          if (!cancelled) setData(res)
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'unknown error')
+        })
+    }
+    fetchOnce()
+    const id = window.setInterval(fetchOnce, POLL_MS)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [api])
+
+  return (
+    <section className="mx-auto max-w-6xl space-y-6">
+      <header>
+        <p className="text-xs uppercase tracking-[0.2em] text-amber-500">Phase 2</p>
+        <h2 className="mt-1 text-2xl font-semibold text-white">Queue</h2>
+        <p className="mt-1 text-sm text-navy-300">
+          What's running, what's waiting, what just finished. Polled every {POLL_MS / 1000}s.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="panel border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {!data ? <div className="panel h-32 animate-pulse" /> : null}
+
+      {data ? (
+        <>
+          <Section title="Running" jobs={data.running} kind="running" />
+          <Section title="Queued" jobs={data.queued} kind="queued" />
+          <Section
+            title="Recently completed (last 24h)"
+            jobs={data.recentlyCompleted}
+            kind="completed"
+          />
+        </>
+      ) : null}
+    </section>
+  )
+}
+
+interface SectionProps {
+  title: string
+  jobs: QueueResponse['running']
+  kind: 'running' | 'queued' | 'completed'
+}
+
+function Section({ title, jobs, kind }: SectionProps) {
+  return (
+    <div className="panel">
+      <header className="panel-header">
+        <h3 className="font-medium text-white">{title}</h3>
+        <span className="text-xs text-navy-400">{jobs.length}</span>
+      </header>
+      {jobs.length === 0 ? (
+        <p className="px-5 py-6 text-sm text-navy-400">(empty)</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="text-left text-xs uppercase tracking-wide text-navy-400">
+            <tr>
+              <th className="px-5 py-2">Job</th>
+              <th className="px-5 py-2">Project</th>
+              <th className="px-5 py-2">Source</th>
+              <th className="px-5 py-2">Status</th>
+              <th className="px-5 py-2">Time</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-navy-700/70">
+            {jobs.map((j) => {
+              const time =
+                kind === 'running'
+                  ? `running for ${formatDuration(j.startedAt ?? j.enqueuedAt, null)}`
+                  : kind === 'queued'
+                    ? `queued ${formatDateTime(j.enqueuedAt)}`
+                    : `${formatDateTime(j.endedAt)} · ${formatDuration(
+                        j.startedAt ?? j.enqueuedAt,
+                        j.endedAt,
+                      )}`
+              return (
+                <tr key={j.id}>
+                  <td className="px-5 py-2 font-mono text-navy-200">{j.id.slice(0, 8)}</td>
+                  <td className="px-5 py-2">
+                    {j.sessionId ? (
+                      <Link
+                        to={`/sessions/${j.sessionId}`}
+                        className="text-amber-400 hover:underline"
+                      >
+                        session →
+                      </Link>
+                    ) : (
+                      <span className="font-mono text-xs text-navy-300">{j.projectId.slice(0, 8)}</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-2 text-navy-200">{j.source}</td>
+                  <td className="px-5 py-2 text-navy-200">{j.status}</td>
+                  <td className="px-5 py-2 text-navy-300">{time}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/Schedule.tsx
+++ b/packages/dashboard/src/pages/Schedule.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ListScheduleResponse, ScheduleEntry } from '@maestro/api'
+import { useApi } from '../hooks/useApi'
+import { formatDateTime } from '../lib/format'
+
+const SCHEDULE_PRESETS: Array<{ label: string; expr: string }> = [
+  { label: 'every 6 hours', expr: '0 */6 * * *' },
+  { label: 'every 4 hours', expr: '0 */4 * * *' },
+  { label: 'twice daily (08:00 and 20:00)', expr: '0 8,20 * * *' },
+  { label: 'morning only (08:00)', expr: '0 8 * * *' },
+  { label: 'weekday mornings', expr: '0 8 * * 1-5' },
+  { label: 'custom — edit the field', expr: '' },
+]
+
+const ALL_WEEKDAYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const
+
+export function Schedule() {
+  const api = useApi()
+  const [data, setData] = useState<ListScheduleResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [savingSlug, setSavingSlug] = useState<string | null>(null)
+
+  const refresh = useCallback(() => {
+    void api
+      .get<ListScheduleResponse>('/api/schedule')
+      .then(setData)
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : 'unknown'))
+  }, [api])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const toggle = async (entry: ScheduleEntry, enabled: boolean) => {
+    setSavingSlug(entry.slug)
+    try {
+      const path = enabled ? 'enable' : 'disable'
+      await api.post(`/api/projects/${encodeURIComponent(entry.slug)}/scheduling/${path}`)
+      refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'unknown')
+    } finally {
+      setSavingSlug(null)
+    }
+  }
+
+  const updateSchedule = async (entry: ScheduleEntry, body: Record<string, unknown>) => {
+    setSavingSlug(entry.slug)
+    try {
+      await api.post(`/api/projects/${encodeURIComponent(entry.slug)}/schedule`, body)
+      refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'unknown')
+    } finally {
+      setSavingSlug(null)
+    }
+  }
+
+  return (
+    <section className="mx-auto max-w-6xl">
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-amber-500">Phase 2</p>
+        <h2 className="mt-1 text-2xl font-semibold text-white">Schedule</h2>
+        <p className="mt-1 text-sm text-navy-300">
+          One row per registered project. Scheduling is opt-in — toggle a project on once
+          manual sessions prove it's healthy.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="panel mb-4 border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {!data ? (
+        <div className="panel h-32 animate-pulse" />
+      ) : data.entries.length === 0 ? (
+        <div className="panel px-6 py-12 text-center">
+          <h3 className="text-lg font-semibold text-white">No projects registered</h3>
+          <p className="mt-2 text-sm text-navy-300">
+            Add one with{' '}
+            <code className="rounded bg-navy-950/70 px-2 py-0.5 text-amber-200">
+              maestro add &lt;repo-url&gt;
+            </code>
+            . Scheduling is off by default for new projects.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {data.entries.map((e) => (
+            <article key={e.slug} className="panel px-5 py-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <Link
+                    to={`/projects/${e.slug}`}
+                    className="font-mono text-sm text-navy-100 hover:underline"
+                  >
+                    {e.slug}
+                  </Link>
+                  {e.autoPausedAt ? (
+                    <span className="pill ml-3 border-amber-700/60 bg-amber-900/30 text-amber-300">
+                      auto-paused
+                    </span>
+                  ) : null}
+                </div>
+                <label className="flex items-center gap-2 text-sm text-navy-200">
+                  <span>scheduling</span>
+                  <input
+                    type="checkbox"
+                    checked={e.scheduledEnabled}
+                    disabled={savingSlug === e.slug}
+                    onChange={(ev) => void toggle(e, ev.target.checked)}
+                  />
+                </label>
+              </div>
+              <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-navy-400">Schedule</dt>
+                  <dd>
+                    <select
+                      className="bg-navy-950 text-navy-100"
+                      value={e.schedule}
+                      onChange={(ev) => {
+                        const v = ev.target.value
+                        if (v === '') return
+                        void updateSchedule(e, { schedule: v })
+                      }}
+                    >
+                      {SCHEDULE_PRESETS.map((p) => (
+                        <option key={p.expr} value={p.expr || e.schedule}>
+                          {p.label}
+                        </option>
+                      ))}
+                      <option value={e.schedule}>{e.schedule}</option>
+                    </select>
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-navy-400">Skip days</dt>
+                  <dd className="flex flex-wrap gap-1 text-xs">
+                    {ALL_WEEKDAYS.map((d) => {
+                      const active = e.skipDays.includes(d)
+                      return (
+                        <button
+                          key={d}
+                          type="button"
+                          onClick={() =>
+                            updateSchedule(e, {
+                              skipDays: active
+                                ? e.skipDays.filter((x) => x !== d)
+                                : [...e.skipDays, d],
+                            })
+                          }
+                          className={`rounded px-1.5 py-0.5 ${
+                            active
+                              ? 'border border-amber-700/60 bg-amber-900/40 text-amber-200'
+                              : 'border border-navy-700 bg-navy-900 text-navy-400 hover:border-navy-500'
+                          }`}
+                        >
+                          {d.slice(0, 3)}
+                        </button>
+                      )
+                    })}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-navy-400">Next run</dt>
+                  <dd className="text-navy-200">
+                    {e.scheduledEnabled ? formatDateTime(e.nextRunAt) : '—'}
+                  </dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- New \`/schedule\` page — toggle scheduling per project, edit schedule via preset dropdown, multi-select skip days, next-run column.
- New \`/queue\` page — running / queued / recently completed (24 h), polled every 5 s.
- ProjectDetail gains a Scheduling panel with auto-pause indicator + one-click resume + recent skips.
- Layout NAV adds Schedule and Queue between Pull Requests and Costs.
- Schedule edits hot-reload via \`scheduler.reconcileNow()\` from #22.

## Test plan
- [x] \`pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm test\` — 65/65 green
- [x] Build produces an updated bundle (~208 KB JS, 16 KB CSS)
- [x] Renders correctly at zero registered projects (umbrella #17 hard requirement)

Part of #17. Closes #23.