### PR TITLE
[#24] test,docs: Phase 2 integration tests, SCHEDULING.md, ADRs

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -305,4 +305,70 @@ If a future agent implementation ignores SIGTERM, the `budget + 30s` SIGKILL sti
 
 ---
 
+## ADR-020: In-memory job queue, opt-in scheduling, no Redis/Bull in v1
+
+**Date**: 2026-05-02
+**Decision**: Phase 2 ships an in-memory `JobQueue` backed by a SQLite `job_queue` table for crash recovery. We deliberately do NOT introduce Redis/Bull/BullMQ. Scheduling is also opt-in per project: every existing and new project starts with `scheduledEnabled = false`.
+
+**Reasoning**:
+- Single-conductor, single-host topology (ADR-002 / ADR-012). A second process layer would buy queueing semantics we already get atomically from SQLite.
+- The full v1 working set fits in memory (≤ 10 projects × handful of queued jobs). Redis would be a deployment burden disproportionate to the workload.
+- Crash recovery is the one Redis/Bull benefit we genuinely need. We get it from the SQLite-backed queue: `cancelStaleOnBoot()` marks rows still in `running` after a previous boot as `cancelled` with reason `conductor-restart`. The next pump finds open slots immediately.
+- Opt-in scheduling is a safety property. Phase 2 must work with zero projects registered (umbrella #17 hard requirement). Defaulting `scheduledEnabled = false` means we cannot accidentally fire scheduled sessions on a real project the developer hasn't explicitly enabled — even if they had `scheduled: "0 */6 * * *"` in their autonomy.json from Phase 1.
+
+**Alternatives**:
+- (a) BullMQ + Redis — production-ready queueing, but requires Redis on the VPS. Defer until we exceed the in-memory regime (>50 projects or multiple conductors).
+- (b) Auto-enable scheduling on every project — too risky. The "first 2 weeks of any project are for building trust" rule from CLAUDE.md only works if the developer chooses when to flip the switch.
+
+**Implications**:
+- The queue's API is intentionally narrow (`enqueue / cancel / pump / snapshot / stop / hasInFlight`) so we can swap implementations later without touching the scheduler or worker.
+- `MAESTRO_MAX_PARALLEL` (default 2) is the only knob; per-project concurrency stays at 1 enforced by `project_locks` (ADR-012).
+
+---
+
+## ADR-021: Skip rules as a layered, audited stack
+
+**Date**: 2026-05-02
+**Decision**: The six Phase 2 skip rules run in a deterministic, cheapest-first order. Each returns a typed `SkipDecision` (`reason: ScheduleSkipReason`, optional `notes`) or `null`. The first rule that fires short-circuits the chain. Every cron tick — fired or skipped — writes a row to `scheduled_runs` with the action and reason. The audit log is the answer to "why didn't Maestro fire this morning?".
+
+Order:
+
+1. D — `auto-paused` (DB lookup, free)
+2. manual-paused (`autonomy.level === 'paused'`, free)
+3. C — skip-day (date math)
+4. B — max-sessions-per-day (one indexed COUNT)
+5. F — failure-backoff (one indexed SELECT, 3+ consecutive failures → skip)
+6. E — cost-throttle-low-priority / -budget-exceeded (uses `CostRepository.aggregate()`)
+7. A — developer-recently-active (shells out to `git log`)
+
+**Reasoning**: A 1-3 cost-ordered chain pays the 5 ms `git log` only when the cheaper rules let the tick through. The audit log makes skip decisions debuggable — without it, "Maestro didn't run" looks like a system bug instead of a designed behaviour. Typed `ScheduleSkipReason` enums let the dashboard label rows precisely.
+
+**Implications**:
+- Adding a rule means adding a new `ScheduleSkipReason` enum value, a function in `skip-rules.ts`, and a position in the chain.
+- Manual triggers bypass the chain entirely (they go through `JobQueue.enqueue` with `source: 'manual'`, not through the scheduler).
+- Auto-pause is its own state in `projects` (ADR-022) so its detection is O(1) — Rule D doesn't have to walk the failure history every tick.
+
+---
+
+## ADR-022: Hot reload via 30-second polling
+
+**Date**: 2026-05-02
+**Decision**: The scheduler reconciles its registered cron jobs against the projects table by polling every `SCHEDULER_POLL_INTERVAL_MS` (30 s) rather than via a SQLite trigger / WAL hook / event bus. The HTTP API and CLI also call `scheduler.reconcileNow()` after writes so changes made through those paths are instant.
+
+**Reasoning**:
+- 30 s is an acceptable maximum lag for a developer adjusting their own schedules. The two paths that *can* skip the lag (API, CLI) already do via `reconcileNow()`.
+- SQLite triggers can't easily call back into the application layer (would need a cross-process notify channel — Pusher, NOTIFY, etc.).
+- A dedicated event bus (e.g. an EventEmitter exposed from the repositories) would couple every write site to the scheduler and grow more complex as more subsystems subscribe.
+- Polling is observable: a single setInterval, a single `reconcileNow()` method, easy to test deterministically.
+
+**Alternatives**:
+- (a) SQLite WAL-based notify (e.g. `update_hook` from better-sqlite3). Real-time but requires the scheduler to disambiguate which projects changed and re-enter the reconciler in a non-trivial way.
+- (b) In-process EventEmitter on every repository write. Simple but spreads coupling across the codebase.
+
+**Implications**:
+- Schedules written via direct SQL (or a future migration tool) take up to 30 s to take effect. Documented in `docs/SCHEDULING.md`.
+- The poll is unref'd so it doesn't keep the process alive past graceful shutdown.
+
+---
+
 *Add new decisions above this line. Keep them numbered sequentially.*

--- a/README.md
+++ b/README.md
@@ -72,9 +72,25 @@ maestro/
 
 ## Status
 
-Phase 0 — foundation only. The conductor boots, the dashboard renders, the
-database initialises, but no real session execution yet. Phase 1 implements
-single-project session execution end-to-end.
+Phase 2 — scheduling and parallelism. Single-project session execution is
+verified end-to-end (Phase 1). Phase 1.5 added orientation mode, the context
+scaffolder, doctor / reset / gc, cost tracking, and the dashboard's
+ProjectDetail / Costs / PRs pages. Phase 2 layered cron-driven scheduling
+on top: the scheduler enqueues sessions on each project's cron tick, the
+job queue runs them up to `MAESTRO_MAX_PARALLEL` (default 2) concurrently,
+six skip rules suppress dumb decisions, and a 5-strike auto-pause stops
+scheduling on a project that's failing repeatedly.
+
+**Scheduling is opt-in per project.** New projects start with
+`scheduledEnabled: false`. The developer enables explicitly via
+`maestro schedule enable <slug>` once manual sessions prove the project is
+healthy. See [`docs/SCHEDULING.md`](./docs/SCHEDULING.md).
+
+### Phase 2 env vars
+
+- `MAESTRO_MAX_PARALLEL` — global concurrency limit (default 2)
+- `MAESTRO_TZ` — cron timezone (default `UTC`)
+- `MAESTRO_DEVELOPER_ACTIVITY_WINDOW_HOURS` — Rule A window (default 4)
 
 ## License
 

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -132,9 +132,32 @@ rather than trying to "fix" the agent.
 
 ## 9. Enable the schedule (Phase 2)
 
-Phase 1 is manual-only — you trigger every session yourself. Phase 2 wires
-`autonomy.json`'s `schedule` field to a node-cron daemon. You'll be able to
-turn that on by toggling the project from `paused` once Phase 2 lands.
+## 9. Enable the schedule (Phase 2)
+
+Phase 2 ships scheduling as an opt-in feature. Every project starts with
+`scheduledEnabled: false` — even if you wrote a `schedule` string in
+`autonomy.json`. The intentional friction is so a fresh project can't
+accidentally start firing before you've validated it with manual sessions.
+
+Once 3-5 manual sessions on the project produce PRs you'd merge:
+
+```bash
+maestro schedule enable <slug>
+```
+
+The scheduler picks up the change on its next reconcile (default 30 s).
+You can verify the registration and next-run time at the dashboard's
+`/schedule` page or via `maestro schedule list`.
+
+To stop scheduled runs without uninstalling:
+
+```bash
+maestro pause <slug> [--reason "..."]   # blocks scheduled and auto runs
+maestro schedule disable <slug>          # unregisters the cron job
+```
+
+See [`docs/SCHEDULING.md`](./SCHEDULING.md) for the skip rules, the
+auto-pause behaviour, and the troubleshooting guide.
 
 ## Quick reference
 
@@ -145,5 +168,13 @@ maestro list                           # registered projects
 maestro run <slug> --dry-run           # print the prompt only
 maestro run <slug>                     # real session
 maestro inspect <session-id>           # session details + log tail
+maestro doctor [<slug>]                # health check
+maestro reset <slug>                   # blow away the working clone
+maestro gc                             # garbage-collect stale clones
+maestro schedule {enable,disable,list} # Phase 2 scheduling
+maestro pause <slug>                   # pause scheduled + auto runs
+maestro resume <slug>                  # clear pause / auto-pause
+maestro queue                          # running / queued / completed
+maestro skips <slug>                   # audit log per project
 maestro status                         # conductor health
 ```

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -1,0 +1,186 @@
+# Scheduling
+
+How Phase 2 makes Maestro autonomous — and how to tell it when you don't
+want it to fire.
+
+## Lifecycle
+
+A scheduled session goes through this pipeline:
+
+```
+cron tick                         skip rules               job queue           worker
+   │                                  │                       │                  │
+   ▼                                  ▼                       ▼                  ▼
+register node-cron job   evaluateSkipRules(ctx)   enqueue source=schedule   runSession()
+on scheduledEnabled=true                                                      ▲
+projects                                                                      │
+                                  ┌─────────┴─────────┐                       │
+                                  ▼                   ▼                       │
+                            scheduled_runs   `skipped` reason         per-project lock
+                            (enqueued / skipped / failed-to-fire)     concurrency=1
+                                                                              ▲
+                                                                              │
+                                                                       global concurrency
+                                                                       MAESTRO_MAX_PARALLEL
+```
+
+Components:
+
+- **Scheduler** (`packages/conductor/src/scheduler.ts`) — registers a
+  node-cron job per `scheduledEnabled = true` project. Reconciles the
+  registered set against the DB every `SCHEDULER_POLL_INTERVAL_MS`
+  (30 s by default), so schedule edits hot-reload.
+- **Skip rules** (`packages/conductor/src/skip-rules.ts`) — six pure
+  functions that decide whether a tick should produce a queued job.
+- **Job queue** (`packages/conductor/src/job-queue.ts`) — in-memory
+  queue with SQLite persistence. Per-project concurrency = 1 (ADR-008);
+  global concurrency = `MAESTRO_MAX_PARALLEL` (default 2).
+- **Audit log** (`scheduled_runs` table) — every cron tick records a
+  row with `action ∈ {enqueued, skipped, failed-to-fire}` and a typed
+  `skip_reason` when relevant.
+
+## Opt-in by project
+
+Scheduling is **opt-in per project**. New projects added via
+`maestro add` start with `scheduledEnabled: false`. The developer
+enables it explicitly when ready:
+
+```bash
+maestro schedule enable <slug>
+```
+
+This is on purpose — see umbrella issue #17 and ADR-020. The "first few
+manual sessions prove the project is healthy" rule from
+`PROJECT_ONBOARDING.md` is what makes the difference between scheduled
+sessions producing PRs you'd merge and scheduled sessions producing
+noise.
+
+## Skip rules
+
+Layered cheapest-first so a tick on an auto-paused project doesn't pay
+for a `git log` probe.
+
+| # | Rule | Reason code | Cost |
+|---|------|-------------|------|
+| D | Project is auto-paused (`projects.auto_paused_at` set) | `auto-paused` | DB lookup |
+| — | Project is manually paused (`autonomy.json level=paused`) | `manual-paused` | autonomy field |
+| C | Today is in `skipDays` | `skip-day` | date math |
+| B | `maxSessionsPerDay` cap reached | `max-sessions-per-day` | one indexed COUNT |
+| F | 3+ consecutive failed sessions | `failure-backoff` | one indexed SELECT |
+| E | Cost throttle: ≥80% → skip `priority: low`; ≥95% → skip everything | `cost-throttle-low-priority` / `cost-throttle-budget-exceeded` | reuses CostRepository.aggregate() |
+| A | Developer committed in last `MAESTRO_DEVELOPER_ACTIVITY_WINDOW_HOURS` (default 4) | `developer-recently-active` | `git log` on the working clone |
+
+Manual triggers (`maestro run <slug>`, dashboard "trigger now",
+`POST /api/projects/:slug/trigger`) bypass all skip rules. They get
+`source='manual'` and `priority=100`, so they jump ahead of any queued
+scheduled jobs.
+
+## Auto-pause
+
+After `AUTO_PAUSE_FAILURE_THRESHOLD` (5) consecutive failed sessions,
+the project is set to `auto_paused_at = now()` and the scheduler stops
+firing it (Rule D). Manual triggers still work; a successful manual
+session clears the auto-pause.
+
+A "failed" session for this purpose means:
+- `status !== 'completed'`, OR
+- `status === 'completed'` but `pr_number IS NULL` after a
+  non-orientation session.
+
+`completed-no-changes` and orientation sessions don't count as
+failures.
+
+## Job queue
+
+In-memory FIFO with priority override:
+
+```
+priority DESC, enqueued_at ASC
+```
+
+Source defaults: `manual=100`, `retry=50`, `schedule=0`.
+
+The picker walks the entire queue and returns the first job whose
+project isn't already in flight. So project A with 5 queued jobs can't
+starve project B's 1 queued job — when a slot opens, the picker walks
+past A's stack and finds B.
+
+On boot, the queue calls `cancelStaleOnBoot()`, which marks any rows
+still in `running` from a previous boot as `cancelled` with reason
+`conductor-restart`. This means a crash mid-session doesn't leave a
+permanently-occupied slot — the scheduler can fire again on the next
+tick.
+
+## Configuration
+
+### `autonomy.json`
+
+```json
+{
+  "scheduledEnabled": false,    // opt-in flag
+  "schedule": "0 */6 * * *",    // standard cron expression
+  "skipDays": ["saturday", "sunday"],
+  "maxSessionsPerDay": 6,
+  "priority": "normal",         // 'high' | 'normal' | 'low'
+  // … plus the existing Phase 1 fields
+}
+```
+
+### Environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `MAESTRO_MAX_PARALLEL` | 2 | Global ceiling on concurrent sessions |
+| `MAESTRO_TZ` | `UTC` | Timezone for cron expressions |
+| `MAESTRO_DEVELOPER_ACTIVITY_WINDOW_HOURS` | 4 | Rule A window |
+| `MAESTRO_BUDGET_USD` | 50 | Monthly budget for cost throttling (rule E) |
+
+## Troubleshooting
+
+### "Why didn't Maestro fire this morning?"
+
+```bash
+maestro skips <slug>
+```
+
+shows the last 20 `scheduled_runs` rows with action + `skip_reason`.
+The dashboard's ProjectDetail Scheduling panel surfaces the same.
+
+If the skip reason is:
+
+- `auto-paused` — the project crossed the failure threshold. Run
+  `maestro resume <slug>` after fixing the underlying issue.
+- `manual-paused` — `autonomy.json level=paused`. Edit the file or run
+  `maestro schedule enable <slug>` once unpaused.
+- `skip-day` — today is in `skipDays`. By design.
+- `max-sessions-per-day` — already ran `maxSessionsPerDay` times today.
+- `failure-backoff` — last 3 sessions failed; backing off until a
+  successful manual run resets the counter.
+- `cost-throttle-*` — monthly budget threshold reached. Increase
+  `MAESTRO_BUDGET_USD` or wait for the rolling 30-day window to roll.
+- `developer-recently-active` — you committed in the last 4 hours;
+  Maestro deferred to you.
+
+### "Schedule edit doesn't seem to take effect"
+
+The scheduler reconciles every 30 s by default. The API endpoint and
+CLI both call `scheduler.reconcileNow()` so changes through those paths
+are immediate. If you edited the SQLite row directly (don't), wait up
+to `SCHEDULER_POLL_INTERVAL_MS`.
+
+### "I want to stop everything fast"
+
+```bash
+maestro pause <slug>           # one project
+# or
+maestro schedule disable <slug>  # one project, more permanent
+```
+
+Send SIGTERM to the conductor to drain in-flight jobs and exit cleanly:
+
+```bash
+kill -TERM $(pgrep -f 'node .*conductor/dist/index.js')
+```
+
+Crash recovery on the next boot will mark any in-flight jobs as
+`cancelled` with reason `conductor-restart`.

--- a/packages/conductor/src/test/scheduling-integration.test.ts
+++ b/packages/conductor/src/test/scheduling-integration.test.ts
@@ -1,0 +1,221 @@
+// End-to-end integration test for Phase 2: cron tick → skip rules →
+// queue → runner → DB transitions. Uses a mock cron and a mock job
+// runner so the test runs deterministically without spawning Claude or
+// touching real time.
+//
+// Three projects are wired up to verify FIFO + per-project concurrency
+// + global concurrency together — the load-bearing invariants of
+// ADR-008.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type cron from 'node-cron'
+import { openDatabase, type DbHandle } from '../db.js'
+import {
+  JobQueueRepository,
+  ProjectRepository,
+  ScheduledRunsRepository,
+} from '../repositories.js'
+import { JobQueue, type JobRunOutcome } from '../job-queue.js'
+import { startScheduler } from '../scheduler.js'
+import { DEFAULT_AUTONOMY_CONFIG, type Job } from '@maestro/shared'
+import type { Config } from '../config.js'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-int-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+const FIXTURE_CONFIG: Config = {
+  port: 0,
+  dataDir: '/tmp/whatever',
+  developerName: 'Tester',
+  developerEmail: 'tester@example.com',
+  developerGithubUsername: 'tester',
+  nodeEnv: 'test',
+}
+
+interface MockCron {
+  impl: typeof cron
+  triggerAll: () => Promise<void>
+}
+
+function mockCron(): MockCron {
+  type Task = { stop: () => void; running: boolean; expr: string; fn: () => void }
+  type CronModule = typeof cron
+  type CronSchedule = ReturnType<CronModule['schedule']>
+  const tasks = new Map<string, Task>()
+  const impl = {
+    validate: () => true,
+    schedule: (expr: string, fn: () => void) => {
+      const id = randomUUID()
+      const task: Task = {
+        stop: () => {
+          tasks.delete(id)
+        },
+        running: true,
+        expr,
+        fn,
+      }
+      tasks.set(id, task)
+      return task as unknown as CronSchedule
+    },
+    getTasks: () => new Map(),
+  } as unknown as CronModule
+  return {
+    impl,
+    triggerAll: async () => {
+      for (const t of tasks.values()) {
+        t.fn()
+        await new Promise((resolve) => setImmediate(resolve))
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+    },
+  }
+}
+
+function addProject(slug: string): string {
+  if (!h) throw new Error('harness missing')
+  const id = randomUUID()
+  new ProjectRepository(h.db.db).insert({
+    id,
+    slug,
+    repoUrl: `https://github.com/example/${slug}`,
+    autonomyConfig: {
+      ...DEFAULT_AUTONOMY_CONFIG,
+      schedule: '*/5 * * * *',
+      scheduledEnabled: true,
+    },
+  })
+  return id
+}
+
+describe('Phase 2 integration', () => {
+  it('three scheduled projects flow through the queue with concurrency = 2', async () => {
+    if (!h) throw new Error('harness missing')
+    const ids = [addProject('a'), addProject('b'), addProject('c')]
+
+    const startedJobs: Job[] = []
+    const completed: string[] = []
+    const finishers = new Map<string, () => void>()
+    const runner = (job: Job) => {
+      startedJobs.push(job)
+      return new Promise<JobRunOutcome>((resolve) => {
+        finishers.set(job.id, () => {
+          completed.push(job.id)
+          resolve({ status: 'completed', sessionId: null })
+        })
+      })
+    }
+    const queue = new JobQueue({ db: h.db.db, runner, maxParallel: 2 })
+    const cron = mockCron()
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: cron.impl,
+      pollIntervalMs: 100_000,
+    })
+    expect(sch.registeredSlugs().sort()).toEqual(['a', 'b', 'c'])
+
+    // Fire every cron job once.
+    await cron.triggerAll()
+    // Pump runs in a microtask after enqueue; let the queue settle.
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    // Two projects should be running, one queued (concurrency = 2).
+    const queueRepo = new JobQueueRepository(h.db.db)
+    expect(queueRepo.listRunning()).toHaveLength(2)
+    expect(queueRepo.listQueued()).toHaveLength(1)
+
+    // Every cron tick wrote an 'enqueued' scheduled_runs row.
+    const runs = new ScheduledRunsRepository(h.db.db)
+    for (const id of ids) {
+      const list = runs.recentForProject(id)
+      expect(list[0]?.action).toBe('enqueued')
+    }
+
+    // Finish one running job; the queued one should pick up the slot.
+    const firstId = startedJobs[0]!.id
+    finishers.get(firstId)!()
+    await new Promise((resolve) => setImmediate(resolve))
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(completed).toContain(firstId)
+    expect(queueRepo.listRunning()).toHaveLength(2)
+    expect(queueRepo.listQueued()).toHaveLength(0)
+
+    // Finish the rest.
+    for (const j of startedJobs.slice(1)) finishers.get(j.id)?.()
+    // The third job (which started after the first finished) is in startedJobs already.
+    // Wait for everything to drain.
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setImmediate(resolve))
+      if (queueRepo.listRunning().length === 0) break
+    }
+
+    expect(queueRepo.listRunning()).toHaveLength(0)
+    expect(queueRepo.listQueued()).toHaveLength(0)
+    expect(completed).toHaveLength(3)
+    await sch.stop()
+  }, 10_000)
+
+  it('a tick on an auto-paused project records a skip without enqueueing', async () => {
+    if (!h) throw new Error('harness missing')
+    const id = addProject('p')
+    new ProjectRepository(h.db.db).setAutoPause('p', '5 consecutive failures')
+
+    const runner = () =>
+      Promise.resolve<JobRunOutcome>({ status: 'completed', sessionId: null })
+    const queue = new JobQueue({ db: h.db.db, runner, maxParallel: 2 })
+    const cron = mockCron()
+    const sch = startScheduler({
+      db: h.db.db,
+      config: FIXTURE_CONFIG,
+      queue,
+      cronImpl: cron.impl,
+      pollIntervalMs: 100_000,
+    })
+
+    await cron.triggerAll()
+    const runs = new ScheduledRunsRepository(h.db.db).recentForProject(id)
+    expect(runs[0]?.action).toBe('skipped')
+    expect(runs[0]?.skipReason).toBe('auto-paused')
+    expect(new JobQueueRepository(h.db.db).listQueued()).toHaveLength(0)
+    await sch.stop()
+  })
+
+  it('manual triggers bypass skip rules — Rule D auto-paused gets a manual trigger', () => {
+    if (!h) throw new Error('harness missing')
+    const id = addProject('p')
+    new ProjectRepository(h.db.db).setAutoPause('p', 'paused')
+
+    const runner = () =>
+      Promise.resolve<JobRunOutcome>({ status: 'completed', sessionId: null })
+    const queue = new JobQueue({ db: h.db.db, runner, maxParallel: 1 })
+
+    // Direct enqueue with source='manual' (the API endpoint /trigger
+    // does this). Skip rules don't apply because the scheduler isn't
+    // involved.
+    queue.enqueue({ projectId: id, source: 'manual' })
+    expect(new JobQueueRepository(h.db.db).listQueued().length + new JobQueueRepository(h.db.db).listRunning().length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Final Phase 2 sub-issue. Cross-component integration test, the operator-facing scheduling guide, three new ADRs.

### Integration test

\`scheduling-integration.test.ts\` (3 tests) wires up scheduler + skip rules + job queue + a mock cron + a deferred runner and exercises:

- 3 scheduled projects → 2 running, 1 queued (concurrency = 2 honoured)
- Auto-paused project records 'skipped' with reason 'auto-paused', no job enqueued
- Manual triggers bypass skip rules

### Docs

- \`docs/SCHEDULING.md\` — end-to-end guide: lifecycle, skip-rule reference, auto-pause, queue starvation guard, configuration, troubleshooting (\"why didn't Maestro fire this morning?\")
- \`docs/PROJECT_ONBOARDING.md\` — section 9 \"Enable the schedule\" rewritten for the real Phase 2 flow; quick-reference updated
- \`README.md\` — status updated to Phase 2 complete; new env vars listed

### ADRs

- ADR-020: in-memory job queue, opt-in scheduling, no Redis/Bull in v1
- ADR-021: skip rules as a layered, audited stack
- ADR-022: hot reload via 30-second polling

## Test plan
- [x] \`pnpm install && pnpm build && pnpm typecheck && pnpm lint && pnpm test\` — 68/68 green
- [x] Manual smoke: conductor boots, scheduler reports 0 registered jobs (correct — no projects opted into scheduling), \`/api/schedule\` and \`/api/queue\` return correct shapes

Part of #17. Closes #24. With this merged the umbrella issue #17 closes.