### PR TITLE
[#34] fix(config): resolve MAESTRO_DATA_DIR relative to .env dir

### DIFF
--- a/packages/conductor/src/config.ts
+++ b/packages/conductor/src/config.ts
@@ -3,9 +3,18 @@
 
 import { config as loadDotenv } from 'dotenv'
 import { existsSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { dirname, isAbsolute, resolve } from 'node:path'
 import { z } from 'zod'
 import { DEFAULT_DATA_DIR, DEFAULT_PORT, MaestroError } from '@maestro/shared'
+
+// The directory containing the .env file we loaded — used as the
+// resolution root for relative paths in env values like
+// MAESTRO_DATA_DIR=./data. Without this, the same .env produces
+// different absolute paths depending on whether the process was
+// launched from the repo root (CLI) or from packages/conductor (`pnpm
+// dev`), which silently splits one logical SQLite database into two
+// (issue #34).
+let envFileDir: string | null = null
 
 // Walk up from cwd looking for a .env so that running the conductor from
 // inside packages/conductor still picks up the repo-root .env in development.
@@ -17,6 +26,7 @@ function loadEnvFile(): void {
     const candidate = resolve(dir, '.env')
     if (existsSync(candidate)) {
       loadDotenv({ path: candidate })
+      envFileDir = dir
       return
     }
     const parent = dirname(dir)
@@ -62,5 +72,21 @@ export function loadConfig(): Config {
     })
   }
 
-  return parsed.data
+  // Stabilise dataDir against the .env's directory rather than the
+  // process cwd. Absolute paths pass through unchanged.
+  const dataDir = resolveAgainstEnvFile(parsed.data.dataDir)
+
+  return { ...parsed.data, dataDir }
+}
+
+/**
+ * Resolve a relative path against the directory that contained the
+ * `.env` we loaded (typically the repo root). Absolute paths are
+ * returned unchanged. Falls back to the process cwd when no `.env`
+ * was found — matches the pre-fix behaviour for that edge case.
+ */
+function resolveAgainstEnvFile(p: string): string {
+  if (isAbsolute(p)) return p
+  const base = envFileDir ?? process.cwd()
+  return resolve(base, p)
 }


### PR DESCRIPTION
## Summary
- Fixes #34 — relative `MAESTRO_DATA_DIR` was resolved against `process.cwd()`, so the CLI (cwd=repo root) and `pnpm dev` (cwd=packages/conductor) opened **different** SQLite files. Result: dashboard showed no data even though `maestro add` succeeded.
- `config.ts` now records the directory where `.env` was discovered during the walk-up and resolves relative `dataDir` against that. Absolute paths pass through unchanged.
- Falls back to cwd when no `.env` is found, matching pre-fix behaviour for that edge case.

## Test plan
- [x] `pnpm --filter @maestro/conductor test` — 68/68 pass
- [x] Manual: `pnpm dev` from `packages/conductor/` resolves to `<repo>/data`, same as `maestro` CLI from repo root
- [ ] Reviewer to delete the orphan `packages/conductor/data/maestro.db` after merge