### PR TITLE
[#36] feat(worker): implement level: full — auto-squash-merge PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,7 @@ Stable project context. Architecture, conventions, key files, gotchas. The agent
 
 ### Autonomy levels
 
-- **`full`** — agent can commit directly to main. Reserved for low-risk projects (small experiments, dotfiles, etc.). Rare.
+- **`full`** — agent opens a PR and auto-merges it (squash) once gates pass. If branch protection blocks the merge the PR is left open with a note in the session results. Reserved for low-risk projects (small experiments, dotfiles, etc.). Rare.
 - **`pr-only`** — agent opens regular PRs, developer merges. Default for most projects.
 - **`draft-only`** — agent opens draft PRs that explicitly need review. For high-risk projects (anything financial, anything in production).
 - **`paused`** — Maestro doesn't touch this project until unpaused.
@@ -323,7 +323,7 @@ The system prompt should explicitly tell the agent:
 ## What NOT to Do
 
 - NEVER store API keys or secrets in `.maestro/` files (those are in repos)
-- NEVER push to main directly except in `full` autonomy mode
+- NEVER push to main directly — even in `full` autonomy mode the agent opens a PR and auto-merges it (squash) so there is always a PR record
 - NEVER open more than 1 PR per project per session
 - NEVER use `--no-verify` or skip quality gates
 - NEVER make commits without the developer's git identity configured

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -40,7 +40,9 @@ The autonomy levels are described in `CLAUDE.md`:
 
 - `pr-only` — agent opens regular PRs, you merge. Default for most projects.
 - `draft-only` — agent opens draft PRs that explicitly need review.
-- `full` — agent commits directly to main. Reserved for low-risk projects.
+- `full` — agent opens a PR and auto-merges it (squash) once gates pass.
+  Reserved for low-risk projects. If branch protection blocks the merge, the
+  PR is left open and the session notes record the reason.
 - `paused` — Maestro doesn't touch this project until unpaused.
 
 ## 2. Edit `context.md` to taste

--- a/packages/conductor/src/pr-manager.ts
+++ b/packages/conductor/src/pr-manager.ts
@@ -19,6 +19,7 @@ import { logger } from './logger.js'
 
 export interface GitHubClient {
   createPullRequest(input: CreatePullRequestInput): Promise<PullRequest>
+  mergePullRequest(input: MergePullRequestInput): Promise<MergePullRequestResult>
   addLabels(input: AddLabelsInput): Promise<void>
   listOpenPullRequests(repo: RepoCoords): Promise<PullRequest[]>
   verifyScopes(): Promise<void>
@@ -44,6 +45,19 @@ export interface AddLabelsInput {
   prNumber: number
   labels: string[]
 }
+
+export interface MergePullRequestInput {
+  repo: RepoCoords
+  prNumber: number
+  /** Defaults to 'squash' — the agent's WIP commits collapse to one PR commit. */
+  method?: 'merge' | 'squash' | 'rebase'
+  commitTitle?: string
+  commitMessage?: string
+}
+
+export type MergePullRequestResult =
+  | { status: 'merged'; sha: string }
+  | { status: 'blocked'; reason: string }
 
 // ─── Construction ────────────────────────────────────────────────────
 
@@ -104,6 +118,33 @@ export function createGitHubClient(input: CreateGitHubClientInput): GitHubClient
           labels: req.labels,
         })
       }, 'addLabels')
+    },
+
+    async mergePullRequest(req) {
+      // Branch protection / unmergeable states return 405/409 from
+      // GitHub. Surface those as a structured `blocked` outcome rather
+      // than throwing, so a `level: full` session leaves the PR open
+      // for the developer to merge manually instead of failing the
+      // whole run.
+      try {
+        const { data } = await octokit.pulls.merge({
+          owner: req.repo.owner,
+          repo: req.repo.repo,
+          pull_number: req.prNumber,
+          merge_method: req.method ?? 'squash',
+          commit_title: req.commitTitle,
+          commit_message: req.commitMessage,
+        })
+        return { status: 'merged', sha: data.sha }
+      } catch (err) {
+        const status = (err as { status?: number }).status
+        if (status === 405 || status === 409 || status === 422) {
+          const message = err instanceof Error ? err.message : String(err)
+          logger.warn({ prNumber: req.prNumber, status, message }, 'auto-merge blocked')
+          return { status: 'blocked', reason: message }
+        }
+        throw err
+      }
     },
 
     async listOpenPullRequests(repo) {

--- a/packages/conductor/src/test/worker.test.ts
+++ b/packages/conductor/src/test/worker.test.ts
@@ -142,14 +142,17 @@ async function setupHarness(scenario: 'all-good' | 'failing-gate'): Promise<Harn
 interface FakeGitHub extends GitHubClient {
   created: CreatePullRequestInput[]
   labelsAdded: AddLabelsInput[]
+  merged: { prNumber: number; method?: string }[]
 }
 
-function fakeGitHub(): FakeGitHub {
+function fakeGitHub(opts: { mergeBlocked?: boolean } = {}): FakeGitHub {
   const created: CreatePullRequestInput[] = []
   const labelsAdded: AddLabelsInput[] = []
+  const merged: { prNumber: number; method?: string }[] = []
   return {
     created,
     labelsAdded,
+    merged,
     async createPullRequest(req) {
       created.push(req)
       return {
@@ -164,6 +167,13 @@ function fakeGitHub(): FakeGitHub {
         mergedAt: null,
         sessionId: null,
       }
+    },
+    async mergePullRequest(req) {
+      merged.push({ prNumber: req.prNumber, method: req.method })
+      if (opts.mergeBlocked) {
+        return { status: 'blocked', reason: 'branch protection requires review' }
+      }
+      return { status: 'merged', sha: 'abcdef0123456789' }
     },
     async addLabels(req) {
       labelsAdded.push(req)
@@ -272,6 +282,78 @@ describe('runSession (integration)', () => {
       expect(result.fixupTurnRan).toBe(true)
     }
   }, 90_000)
+
+  it('level: full auto-merges the PR after creation', async () => {
+    harness = await setupHarness('all-good')
+    const { db, config, slug } = harness
+    const projects = new ProjectRepository(db.db)
+    projects.updateAutonomyConfig(slug, { ...TEST_AUTONOMY, level: 'full' })
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    const gh = fakeGitHub()
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({
+      files: { 'README.md': '# Fixture\n\nAuto-merge path.\n' },
+      branch: `maestro/${slug}/full-mode`,
+      commitMessage: 'chore: full-mode change',
+      stateBody:
+        '# Current State\n\n## Focus\nFull mode.\n\n## Next Concrete Tasks\n- [ ] x\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nx.\n\n## Notes\n\n',
+      journalFilename: '2026-04-29-09-00.md',
+      journalBody: '# Session 2026-04-29T09:00:00.000Z\n\n## Goal\nx.\n',
+    })
+
+    const result = await runSession({
+      db: db.db,
+      config,
+      project,
+      claudeBin: MOCK_CLAUDE,
+      githubClient: gh,
+      skipClaudeProbe: true,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.prNumber).toBe(42)
+    expect(gh.created).toHaveLength(1)
+    expect(gh.created[0]?.draft).toBe(false)
+    expect(gh.merged).toHaveLength(1)
+    expect(gh.merged[0]?.prNumber).toBe(42)
+    expect(gh.merged[0]?.method).toBe('squash')
+    expect(result.notes).toContain('auto-merged')
+  }, 60_000)
+
+  it('level: full leaves PR open with a note when auto-merge is blocked', async () => {
+    harness = await setupHarness('all-good')
+    const { db, config, slug } = harness
+    const projects = new ProjectRepository(db.db)
+    projects.updateAutonomyConfig(slug, { ...TEST_AUTONOMY, level: 'full' })
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    const gh = fakeGitHub({ mergeBlocked: true })
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({
+      files: { 'README.md': '# Fixture\n\nBlocked merge.\n' },
+      branch: `maestro/${slug}/full-blocked`,
+      commitMessage: 'chore: blocked merge',
+      stateBody:
+        '# Current State\n\n## Focus\nx.\n\n## Next Concrete Tasks\n- [ ] x\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nx.\n\n## Notes\n\n',
+      journalFilename: '2026-04-29-10-00.md',
+      journalBody: '# Session 2026-04-29T10:00:00.000Z\n\n## Goal\nx.\n',
+    })
+
+    const result = await runSession({
+      db: db.db,
+      config,
+      project,
+      claudeBin: MOCK_CLAUDE,
+      githubClient: gh,
+      skipClaudeProbe: true,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.prNumber).toBe(42)
+    expect(gh.merged).toHaveLength(1)
+    expect(result.notes).toContain('auto-merge blocked')
+  }, 60_000)
 
   it('refuses to run a second session for the same project (lock)', async () => {
     harness = await setupHarness('all-good')

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -442,6 +442,33 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
     labels: project.autonomyConfig.github.prLabels,
   })
 
+  if (project.autonomyConfig.level === 'full') {
+    const merge = await githubClient.mergePullRequest({
+      repo,
+      prNumber: pr.number,
+      method: 'squash',
+      commitTitle: title,
+    })
+    if (merge.status === 'merged') {
+      logger.info(
+        { prNumber: pr.number, sha: merge.sha, slug: project.slug },
+        'auto-merged PR (level=full)',
+      )
+      return baseFinalize('completed', {
+        prNumber: pr.number,
+        notes: `${pr.url} (auto-merged ${merge.sha.slice(0, 7)})`,
+      })
+    }
+    logger.warn(
+      { prNumber: pr.number, slug: project.slug, reason: merge.reason },
+      'auto-merge blocked; PR left open',
+    )
+    return baseFinalize('completed', {
+      prNumber: pr.number,
+      notes: `${pr.url} (auto-merge blocked: ${merge.reason})`,
+    })
+  }
+
   return baseFinalize('completed', {
     prNumber: pr.number,
     notes: pr.url,


### PR DESCRIPTION
Closes #36.

## Summary
- Add `mergePullRequest` to `GitHubClient`, backed by Octokit `pulls.merge` with `method: squash`.
- In `worker.ts`, when `project.autonomyConfig.level === 'full'`, the PR is auto-merged after creation.
- Branch-protection / unmergeable responses (405/409/422) surface as a structured `blocked` outcome — PR stays open, session still completes, notes carry the reason.
- Docs updated: `level: full` is now "open PR + squash-merge" rather than "commit directly to main", so the audit trail (PR number, gate output, branch) is preserved.

## Test plan
- [x] `pnpm exec vitest run src/test/worker.test.ts` — 5/5 pass, including new auto-merge happy + blocked tests
- [x] `pnpm --filter @maestro/conductor build` — typechecks
- [x] `pnpm exec eslint packages/conductor/src` — clean
- [ ] Reviewer to verify branch-protection blocked path on a real repo before flipping any project to `full`