### PR TITLE
[#41] feat(conductor): opt-in session continuation until budget exhausted

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -395,4 +395,49 @@ Order:
 
 ---
 
+## ADR-024: Opt-in session continuation until budget exhausted
+
+**Date**: 2026-05-02
+**Decision**: Phase 4 / Sub 2 adds two `autonomy.json` fields — `continueUntilBudget` (default `false`) and `minTimeForContinuation` (default 900 s) — that turn one logical session into a chain of "turns" against the same `MAESTRO_DATA_DIR/work/<slug>` clone. Each turn opens its own PR. The session row's `pr_number` reflects the most recent turn; per-turn detail lives in a new `session_turns` table.
+
+After turn N completes successfully, the worker:
+1. Re-reads `.maestro/state.md` (the agent updated it on N's branch).
+2. If there are more "Next Concrete Tasks" AND `total_budget − elapsed − overhead ≥ minTimeForContinuation`, calls `softResetForNextTurn(workingRoot, base)`:
+   - Snapshots `.maestro/` from N's branch tip
+   - `git fetch origin <base>`, checkout, hard-reset to `origin/<base>`
+   - Restores the snapshotted `.maestro/` over the clean base — uncommitted, ready to be carried into N+1's branch by the agent's first commit.
+3. Spawns Claude with a fresh budget = `remaining − CONTINUATION_TURN_OVERHEAD_SECONDS` and a CONTINUATION preamble in the prompt naming the turn number and previous PR numbers.
+4. Records the new turn in `session_turns`. Loops until the predicate fails.
+
+The chain stops when:
+- the last turn's status is anything other than `completed`,
+- the last turn produced no PR (orientation, no-changes),
+- the next turn's budget would fall below `minTimeForContinuation`,
+- the agent removed the last task from `state.md` (heuristic via `deriveTaskFromState`),
+- or `softResetForNextTurn` fails (e.g. base branch missing).
+
+**Reasoning**: Phase 1 sessions used 10–20 % of their 45-minute budget and stopped. The "ONE task per session" rule from PROMPT_DESIGN.md is correct for review hygiene, but it conflates "one task per *commit*" with "one task per *budget window*". With `level: full` already auto-merging each turn's PR (ADR-023), each turn lands as its own squash commit on main, so review hygiene is preserved even when a budget produces three PRs back-to-back. Continuation is the natural next step.
+
+**Why opt-in**: Multi-turn sessions multiply token consumption against the developer's Pro/Max subscription. The default is `false` so existing projects do not silently start consuming N× more. The developer flips it on per project once they trust the loop.
+
+**Why the soft-reset dance**: The agent's `state.md` updates live on its feature branch, not main. If we just reset to main between turns, the next turn would re-read the OLD state.md (with the task we just completed). The agent would then either redo the same task or get confused. Snapshotting `.maestro/` and restoring it on main is the smallest possible change that preserves the agent's reasoning thread across the boundary.
+
+**Subscription cost impact**:
+- Per logical session with N turns: ~N× input tokens (each turn re-reads context.md, state.md, journals, plus Sub 1's feedback section).
+- Output tokens scale with the work each turn does (typically smaller than input).
+- Each fixup turn within a turn (ADR-013) also re-spawns Claude. So a session with two turns and one gate failure consumes three Claude invocations.
+- Recommendation in `docs/PROJECT_ONBOARDING.md`: enable on one project first, monitor rate-limit dashboard for a week, then expand.
+
+**Alternatives considered**:
+- (a) **Single-turn, longer budget** — increase `timeBudget` instead of multi-turn. Rejected because Claude Code's reliability degrades on very long single sessions and the agent doesn't naturally chunk work into PR-sized units without an explicit prompt boundary.
+- (b) **Cherry-pick `.maestro/` commits across turns** instead of snapshot-restore. Rejected as more fragile (requires turn 1's commits to be cleanly separable, which we can't guarantee).
+- (c) **Force the agent to commit `.maestro/` to main directly** (not a feature branch). Rejected — contradicts ADR-005 (PR-only default) and would split state changes from code changes in confusing ways.
+
+**Implications**:
+- New table `session_turns`. Existing single-turn sessions will have exactly one row in this table going forward; pre-existing sessions have none, which the dashboard handles by falling back to the parent `sessions` row.
+- The session's `pr_number` continues to reflect "the latest PR" so existing dashboards keep working. The per-turn drill-down lives in `/api/sessions/:id` once the dashboard surfaces it (Sub 7 territory).
+- `PROMPT_VERSION` is unchanged at `1.2.0` — the CONTINUATION preamble is opt-in via the prompt context, doesn't affect single-turn sessions.
+
+---
+
 *Add new decisions above this line. Keep them numbered sequentially.*

--- a/packages/conductor/src/db/migrations/005_session_turns.sql
+++ b/packages/conductor/src/db/migrations/005_session_turns.sql
@@ -1,0 +1,28 @@
+-- Phase 4 / Sub 2: opt-in session continuation until budget exhausted.
+--
+-- One row per turn within a session. Turn 1 is the agent's initial work;
+-- turn 2+ are continuation runs that fire when autonomy.continueUntilBudget
+-- is true and budget remains. Each turn owns its own branch + PR. The parent
+-- session row's pr_number column reflects the *last* successful turn so
+-- existing dashboards keep working without joins.
+
+CREATE TABLE IF NOT EXISTS session_turns (
+  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id         TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  turn_number        INTEGER NOT NULL CHECK (turn_number >= 1),
+  branch_name        TEXT,
+  pr_number          INTEGER,
+  pr_url             TEXT,
+  status             TEXT NOT NULL CHECK (status IN (
+    'completed','completed-no-changes','quality-gate-failed','timed-out','failed','cancelled'
+  )),
+  cost_cents         INTEGER,
+  started_at         TEXT NOT NULL,
+  ended_at           TEXT,
+  termination_cause  TEXT,
+  notes              TEXT,
+  UNIQUE (session_id, turn_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_turns_session
+  ON session_turns(session_id, turn_number);

--- a/packages/conductor/src/repositories.ts
+++ b/packages/conductor/src/repositories.ts
@@ -11,6 +11,7 @@ import {
   JobSchema,
   ScheduledRunSchema,
   PrFeedbackSchema,
+  SessionTurnSchema,
   type Project,
   type ProjectAutonomyConfig,
   type Session,
@@ -26,6 +27,8 @@ import {
   type ScheduledRunAction,
   type ScheduleSkipReason,
   type PrFeedback,
+  type SessionTurn,
+  type SessionTurnStatus,
   MaestroError,
 } from '@maestro/shared'
 
@@ -887,6 +890,131 @@ export class PrFeedbackRepository {
       )
       .run(projectId, prNumber, stamp)
   }
+}
+
+// ─── Phase 4 / Sub 2: session turns ──────────────────────────────────
+
+interface SessionTurnRow {
+  id: number
+  session_id: string
+  turn_number: number
+  branch_name: string | null
+  pr_number: number | null
+  pr_url: string | null
+  status: SessionTurnStatus
+  cost_cents: number | null
+  started_at: string
+  ended_at: string | null
+  termination_cause: string | null
+  notes: string | null
+}
+
+export interface CreateSessionTurnInput {
+  sessionId: string
+  turnNumber: number
+}
+
+export interface UpdateSessionTurnInput {
+  branchName?: string | null
+  prNumber?: number | null
+  prUrl?: string | null
+  status?: SessionTurnStatus
+  costCents?: number | null
+  endedAt?: string | null
+  terminationCause?: TerminationCause | null
+  notes?: string | null
+}
+
+export class SessionTurnRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  insert(input: CreateSessionTurnInput): SessionTurn {
+    const startedAt = new Date().toISOString()
+    this.db
+      .prepare(
+        `INSERT INTO session_turns (session_id, turn_number, status, started_at)
+         VALUES (?, ?, 'completed', ?)`,
+      )
+      .run(input.sessionId, input.turnNumber, startedAt)
+    const row = this.db
+      .prepare<[string, number], SessionTurnRow>(
+        `SELECT * FROM session_turns WHERE session_id = ? AND turn_number = ?`,
+      )
+      .get(input.sessionId, input.turnNumber)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'session_turn insert lost' })
+    return rowToSessionTurn(row)
+  }
+
+  update(sessionId: string, turnNumber: number, patch: UpdateSessionTurnInput): SessionTurn {
+    const map: Record<string, unknown> = {
+      branch_name: patch.branchName,
+      pr_number: patch.prNumber,
+      pr_url: patch.prUrl,
+      status: patch.status,
+      cost_cents: patch.costCents,
+      ended_at: patch.endedAt,
+      termination_cause: patch.terminationCause,
+      notes: patch.notes,
+    }
+    const setParts: string[] = []
+    const values: unknown[] = []
+    for (const column of Object.keys(map)) {
+      const key = column
+      const value = map[key]
+      if (value === undefined) continue
+      setParts.push(`${column} = ?`)
+      values.push(value)
+    }
+    if (setParts.length === 0) {
+      const existing = this.findByTurn(sessionId, turnNumber)
+      if (!existing) throw new MaestroError('INTERNAL_ERROR', { message: `session_turn ${sessionId}/${turnNumber} missing` })
+      return existing
+    }
+    values.push(sessionId, turnNumber)
+    this.db
+      .prepare(
+        `UPDATE session_turns SET ${setParts.join(', ')} WHERE session_id = ? AND turn_number = ?`,
+      )
+      .run(...values)
+    const row = this.findByTurn(sessionId, turnNumber)
+    if (!row) throw new MaestroError('INTERNAL_ERROR', { message: 'session_turn update lost' })
+    return row
+  }
+
+  findByTurn(sessionId: string, turnNumber: number): SessionTurn | null {
+    const row = this.db
+      .prepare<[string, number], SessionTurnRow>(
+        `SELECT * FROM session_turns WHERE session_id = ? AND turn_number = ?`,
+      )
+      .get(sessionId, turnNumber)
+    return row ? rowToSessionTurn(row) : null
+  }
+
+  listForSession(sessionId: string): SessionTurn[] {
+    const rows = this.db
+      .prepare<[string], SessionTurnRow>(
+        `SELECT * FROM session_turns WHERE session_id = ? ORDER BY turn_number ASC`,
+      )
+      .all(sessionId)
+    return rows.map(rowToSessionTurn)
+  }
+}
+
+function rowToSessionTurn(row: SessionTurnRow): SessionTurn {
+  return SessionTurnSchema.parse({
+    id: row.id,
+    sessionId: row.session_id,
+    turnNumber: row.turn_number,
+    branchName: row.branch_name,
+    prNumber: row.pr_number,
+    prUrl: row.pr_url,
+    status: row.status,
+    costCents: row.cost_cents,
+    startedAt: row.started_at,
+    endedAt: row.ended_at,
+    terminationCause: row.termination_cause,
+    notes: row.notes,
+  })
 }
 
 function rowToPrFeedback(row: PrFeedbackRow): PrFeedback {

--- a/packages/conductor/src/test/continuation.test.ts
+++ b/packages/conductor/src/test/continuation.test.ts
@@ -1,0 +1,221 @@
+// Phase 4 / Sub 2: session continuation tests.
+//
+// Multi-turn integration is exercised by running a real session in
+// production; here we test the components in isolation:
+//   1. SessionTurnRepository CRUD
+//   2. softResetForNextTurn carries .maestro/ across a git reset
+//   3. The prompt's CONTINUATION preamble appears when continuation context
+//      is set, and references previous PR numbers
+//   4. End-to-end: continueUntilBudget=true with a state.md that has no
+//      next task after turn 1 → continuation does NOT trigger (the
+//      `shouldContinue` predicate respects the empty task list)
+
+import { execSync } from 'node:child_process'
+import { mkdtemp, mkdir, rm, writeFile, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomUUID } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { openDatabase, type DbHandle } from '../db.js'
+import {
+  ProjectRepository,
+  SessionRepository,
+  SessionTurnRepository,
+} from '../repositories.js'
+import {
+  buildSessionPrompt,
+  DEFAULT_AUTONOMY_CONFIG,
+  PROMPT_VERSION,
+} from '@maestro/shared'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-cont-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+const here = dirname(fileURLToPath(import.meta.url))
+void here
+
+describe('SessionTurnRepository', () => {
+  it('insert + update + listForSession', () => {
+    if (!h) throw new Error('harness missing')
+    const projects = new ProjectRepository(h.db.db)
+    const projectId = randomUUID()
+    projects.insert({
+      id: projectId,
+      slug: 'p',
+      repoUrl: 'https://github.com/example/p',
+      autonomyConfig: { ...DEFAULT_AUTONOMY_CONFIG },
+    })
+    const sessions = new SessionRepository(h.db.db)
+    const sessionId = randomUUID()
+    sessions.insert({ id: sessionId, projectId, promptVersion: PROMPT_VERSION })
+
+    const turns = new SessionTurnRepository(h.db.db)
+    const t1 = turns.insert({ sessionId, turnNumber: 1 })
+    expect(t1.turnNumber).toBe(1)
+    expect(t1.status).toBe('completed')
+
+    const updated = turns.update(sessionId, 1, {
+      branchName: 'maestro/p/foo',
+      prNumber: 42,
+      prUrl: 'https://github.com/example/p/pull/42',
+      status: 'completed',
+      costCents: 5,
+      endedAt: new Date().toISOString(),
+      notes: 'turn 1 happy path',
+    })
+    expect(updated.prNumber).toBe(42)
+    expect(updated.notes).toBe('turn 1 happy path')
+
+    turns.insert({ sessionId, turnNumber: 2 })
+    const all = turns.listForSession(sessionId)
+    expect(all).toHaveLength(2)
+    expect(all.map((t) => t.turnNumber)).toEqual([1, 2])
+  })
+
+  it('rejects duplicate (session, turn_number)', () => {
+    if (!h) throw new Error('harness missing')
+    const projects = new ProjectRepository(h.db.db)
+    const projectId = randomUUID()
+    projects.insert({
+      id: projectId,
+      slug: 'p',
+      repoUrl: 'https://github.com/example/p',
+      autonomyConfig: { ...DEFAULT_AUTONOMY_CONFIG },
+    })
+    const sessions = new SessionRepository(h.db.db)
+    const sessionId = randomUUID()
+    sessions.insert({ id: sessionId, projectId, promptVersion: PROMPT_VERSION })
+    const turns = new SessionTurnRepository(h.db.db)
+    turns.insert({ sessionId, turnNumber: 1 })
+    expect(() => turns.insert({ sessionId, turnNumber: 1 })).toThrow()
+  })
+})
+
+describe('buildSessionPrompt with continuation', () => {
+  it('includes CONTINUATION preamble and previous PR numbers when continuation context is set', () => {
+    const prompt = buildSessionPrompt({
+      projectName: 'p',
+      projectSlug: 'p',
+      timeBudgetSeconds: 1800,
+      developerName: 'Tester',
+      context: '# context',
+      state: '# state',
+      recentJournal: [],
+      task: 'do task 2',
+      qualityGates: ['test'],
+      continuation: {
+        turnNumber: 2,
+        previousPrNumbers: [42, 43],
+      },
+    })
+    expect(prompt).toContain('== CONTINUATION ==')
+    expect(prompt).toContain('turn 2')
+    expect(prompt).toContain('#42, #43')
+  })
+
+  it('omits CONTINUATION preamble on a normal first turn', () => {
+    const prompt = buildSessionPrompt({
+      projectName: 'p',
+      projectSlug: 'p',
+      timeBudgetSeconds: 1800,
+      developerName: 'Tester',
+      context: '# context',
+      state: '# state',
+      recentJournal: [],
+      task: 'do task',
+      qualityGates: ['test'],
+    })
+    expect(prompt).not.toContain('== CONTINUATION ==')
+  })
+})
+
+describe('softResetForNextTurn', () => {
+  it('preserves .maestro/ contents across a base-branch reset', async () => {
+    if (!h) throw new Error('harness missing')
+    // Set up a tiny git repo: bare remote + working clone with a commit on
+    // main, then a feature branch with a different .maestro/state.md.
+    const root = h.root
+    const remote = join(root, 'remote.git')
+    const work = join(root, 'work')
+    await mkdir(remote, { recursive: true })
+    await mkdir(work, { recursive: true })
+    execSync('git init --bare -b main', { cwd: remote, stdio: 'ignore' })
+    execSync('git init -b main', { cwd: work, stdio: 'ignore' })
+    execSync('git config user.email tester@example.com', { cwd: work })
+    execSync('git config user.name Tester', { cwd: work })
+
+    await mkdir(join(work, '.maestro/journal'), { recursive: true })
+    await writeFile(join(work, '.maestro/state.md'), '# original state')
+    await writeFile(join(work, '.maestro/context.md'), '# original ctx')
+    await writeFile(join(work, '.maestro/journal/.gitkeep'), '')
+    await writeFile(join(work, 'README.md'), '# project')
+    execSync('git add -A && git commit -m init', { cwd: work, stdio: 'ignore' })
+    execSync(`git remote add origin ${remote}`, { cwd: work })
+    execSync('git push -u origin main', { cwd: work, stdio: 'ignore' })
+
+    // Branch off and modify .maestro/state.md to simulate turn 1's work.
+    execSync('git checkout -b maestro/p/turn-1', { cwd: work, stdio: 'ignore' })
+    await writeFile(join(work, '.maestro/state.md'), '# turn-1 updated state')
+    await writeFile(
+      join(work, '.maestro/journal/2026-04-30-08-00-00.md'),
+      '# journal turn 1',
+    )
+    execSync('git add -A && git commit -m "turn 1"', { cwd: work, stdio: 'ignore' })
+    execSync('git push -u origin maestro/p/turn-1', { cwd: work, stdio: 'ignore' })
+
+    // Soft-reset: switch to main, but carry .maestro/ from turn-1's tip.
+    const { softResetForNextTurn } = await import('../worker.js') as unknown as {
+      softResetForNextTurn: (root: string, base: string) => Promise<void>
+    }
+    if (!softResetForNextTurn) {
+      // Fall back: re-import the module shape that's actually exported.
+      // (See `re-exports for tests` block at the bottom of worker.ts.)
+    }
+
+    // Use a workaround: call via the test export, which is added below.
+    const { softResetForNextTurn: fn } = await import('../worker.js')
+    await fn(work, 'main')
+
+    // After soft-reset:
+    //  - working tree should be on main (no turn-1 commits in HEAD log)
+    //  - .maestro/state.md should still hold the turn-1 update
+    //  - the new journal file should still be present in the working tree
+    const headBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: work }).toString().trim()
+    expect(headBranch).toBe('main')
+
+    const log = execSync('git log --format=%s', { cwd: work }).toString().trim()
+    expect(log).toBe('init')
+
+    const carriedState = await readFile(join(work, '.maestro/state.md'), 'utf-8')
+    expect(carriedState).toContain('turn-1 updated state')
+
+    const carriedJournal = await readFile(
+      join(work, '.maestro/journal/2026-04-30-08-00-00.md'),
+      'utf-8',
+    )
+    expect(carriedJournal).toContain('journal turn 1')
+
+    // Those .maestro/ files are uncommitted on main — git status should
+    // show them as modified/added relative to base.
+    const status = execSync('git status --porcelain', { cwd: work }).toString()
+    expect(status.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -25,6 +25,7 @@ import { randomUUID } from 'node:crypto'
 import type Database from 'better-sqlite3'
 import simpleGit, { type SimpleGit } from 'simple-git'
 import {
+  CONTINUATION_TURN_OVERHEAD_SECONDS,
   COST_WARN_PER_SESSION_CENTS,
   FIXUP_TURN_BUDGET_SECONDS,
   LOGS_SUBDIR,
@@ -34,6 +35,7 @@ import {
   buildFixupTurnPrompt,
   buildSessionPrompt,
   isOrientationModeFromContext,
+  type ContinuationContext,
   type Project,
   type SessionStatus,
   type SessionResult,
@@ -49,6 +51,7 @@ import {
   ProjectRepository,
   QualityGateRepository,
   SessionRepository,
+  SessionTurnRepository,
 } from './repositories.js'
 import {
   defaultAllowlistFor,
@@ -122,6 +125,7 @@ export async function runSession(input: RunSessionInput): Promise<RunSessionOutp
   const gates = new QualityGateRepository(input.db)
   const locks = new ProjectLockManager(input.db)
   const projects = new ProjectRepository(input.db)
+  const turns = new SessionTurnRepository(input.db)
 
   // Pre-flight ------------------------------------------------------------------------
   if (!input.dryRun && !input.skipClaudeProbe) {
@@ -139,15 +143,74 @@ export async function runSession(input: RunSessionInput): Promise<RunSessionOutp
         promptVersion: PROMPT_VERSION,
       })
 
+  const sessionStartMs = Date.now()
   let result: RunSessionOutput | null = null
   try {
-    result = await runSessionInner({
-      ...input,
-      sessionId,
-      sessions,
-      gates,
-      projects,
-    })
+    // Turn 1 -----------------------------------------------------------------------
+    let turnNumber = 1
+    if (!input.dryRun) turns.insert({ sessionId, turnNumber })
+    result = await runSessionInner({ ...input, sessionId, sessions, gates, projects })
+    if (!input.dryRun) recordTurnFromResult(turns, sessionId, turnNumber, result)
+
+    // Phase 4 / Sub 2: continuation. Opt-in per autonomy.json. Each turn
+    // gets the remaining budget (minus the per-turn overhead) and opens its
+    // own PR. The loop exits as soon as state.md has no more concrete
+    // tasks, the budget falls below minTimeForContinuation, or the last
+    // turn failed / produced no PR.
+    const previousPrs: number[] = result.prNumber ? [result.prNumber] : []
+    while (
+      !input.dryRun &&
+      input.project.autonomyConfig.continueUntilBudget &&
+      shouldContinueAfterTurn(result, input.project, sessionStartMs)
+    ) {
+      const totalBudget = input.project.autonomyConfig.timeBudget
+      const elapsedSeconds = Math.floor((Date.now() - sessionStartMs) / 1000)
+      const remaining = totalBudget - elapsedSeconds
+      const nextTurnBudget = remaining - CONTINUATION_TURN_OVERHEAD_SECONDS
+      if (nextTurnBudget < input.project.autonomyConfig.minTimeForContinuation) {
+        logger.info(
+          {
+            sessionId,
+            elapsedSeconds,
+            remaining,
+            min: input.project.autonomyConfig.minTimeForContinuation,
+          },
+          'continuation: budget below min — stopping',
+        )
+        break
+      }
+      const workingRoot = workingDirFor(input.config.dataDir, input.project.slug)
+      try {
+        await softResetForNextTurn(
+          workingRoot,
+          input.project.autonomyConfig.branches.base,
+        )
+      } catch (err) {
+        logger.warn({ err, sessionId }, 'continuation: soft-reset failed; stopping')
+        break
+      }
+      // Re-read state.md after the reset; if no remaining tasks, stop.
+      const restoredState = await readMaestroDir(workingRoot)
+      const nextTask = deriveTaskFromState(restoredState.state.raw)
+      if (!nextTask || /^_\(/.test(nextTask)) {
+        logger.info({ sessionId }, 'continuation: state.md has no next task — stopping')
+        break
+      }
+      turnNumber += 1
+      turns.insert({ sessionId, turnNumber })
+      result = await runSessionInner({
+        ...input,
+        sessionId,
+        sessions,
+        gates,
+        projects,
+        continuation: { turnNumber, previousPrNumbers: previousPrs.slice() },
+        timeBudgetSecondsOverride: nextTurnBudget,
+      })
+      recordTurnFromResult(turns, sessionId, turnNumber, result)
+      if (result.prNumber) previousPrs.push(result.prNumber)
+    }
+
     return result
   } catch (err) {
     if (sessionRow) {
@@ -163,11 +226,79 @@ export async function runSession(input: RunSessionInput): Promise<RunSessionOutp
   }
 }
 
+/**
+ * Phase 4 / Sub 2: a turn produced something worth continuing from when:
+ *   - the run completed (status = 'completed'), AND
+ *   - the run actually opened a PR or made changes the agent acknowledged
+ *     in state.md (we use prNumber as the proxy for "the agent did real
+ *     work this turn"), AND
+ *   - we did not hit a quality-gate failure / time-out / failure path.
+ * 'completed-no-changes' explicitly STOPS continuation: the agent told us
+ * there is nothing to do.
+ */
+function shouldContinueAfterTurn(
+  result: RunSessionOutput,
+  _project: Project,
+  _sessionStartMs: number,
+): boolean {
+  if (result.status !== 'completed') return false
+  if (!result.prNumber) return false
+  return true
+}
+
+function recordTurnFromResult(
+  turns: SessionTurnRepository,
+  sessionId: string,
+  turnNumber: number,
+  result: RunSessionOutput,
+): void {
+  // Map RunSessionOutput.status (SessionStatus) onto the narrower turn
+  // status enum. Anything not in the enum collapses to 'failed'.
+  const allowed: ReadonlyArray<RunSessionOutput['status']> = [
+    'completed',
+    'completed-no-changes',
+    'quality-gate-failed',
+    'timed-out',
+    'failed',
+    'cancelled',
+  ]
+  const status = (allowed.includes(result.status) ? result.status : 'failed') as
+    | 'completed'
+    | 'completed-no-changes'
+    | 'quality-gate-failed'
+    | 'timed-out'
+    | 'failed'
+    | 'cancelled'
+  turns.update(sessionId, turnNumber, {
+    branchName: result.branchName,
+    prNumber: result.prNumber,
+    prUrl: result.notes && /https?:\/\//.test(result.notes) ? result.notes.split(' ')[0] ?? null : null,
+    status,
+    costCents: result.costCents,
+    endedAt: new Date().toISOString(),
+    notes: result.notes,
+  })
+}
+
 interface InnerInput extends RunSessionInput {
   sessionId: string
   sessions: SessionRepository
   gates: QualityGateRepository
   projects: ProjectRepository
+  /**
+   * Phase 4 / Sub 2: when set, this is a continuation turn (turn >= 2).
+   * The worker skips prepareWorkingDir (the caller has already done a
+   * soft reset that carries .maestro/ across turns) and the prompt
+   * grows a CONTINUATION preamble.
+   */
+  continuation?: ContinuationContext
+  /**
+   * Phase 4 / Sub 2: per-turn time budget override. When set, replaces
+   * `project.autonomyConfig.timeBudget` for the Claude invocation. Used
+   * by continuation turns so each subsequent turn gets only the
+   * remaining budget, not a fresh full ceiling.
+   */
+  timeBudgetSecondsOverride?: number
 }
 
 async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
@@ -176,13 +307,17 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
   const logPath = sessionLogPath(config.dataDir, input.sessionId)
 
   // Step 2: working directory ------------------------------------------------------
-  await prepareWorkingDir({
-    workingRoot,
-    repoUrl: project.repoUrl,
-    baseBranch: project.autonomyConfig.branches.base,
-    developerName: config.developerName,
-    developerEmail: config.developerEmail ?? `${config.developerGithubUsername}@users.noreply.github.com`,
-  })
+  // Continuation turns (Sub 2) skip the prepare; the caller has already
+  // done a soft reset that carries .maestro/ across the boundary.
+  if (!input.continuation) {
+    await prepareWorkingDir({
+      workingRoot,
+      repoUrl: project.repoUrl,
+      baseBranch: project.autonomyConfig.branches.base,
+      developerName: config.developerName,
+      developerEmail: config.developerEmail ?? `${config.developerGithubUsername}@users.noreply.github.com`,
+    })
+  }
 
   // Step 3: read .maestro/ ----------------------------------------------------------
   const maestro = await readMaestroDir(workingRoot)
@@ -215,10 +350,11 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
   // Step 4: build prompt ------------------------------------------------------------
   const task = deriveTaskFromState(maestro.state.raw)
   const neverTouch = parseNeverTouchSection(maestro.context)
+  const turnTimeBudget = input.timeBudgetSecondsOverride ?? project.autonomyConfig.timeBudget
   const promptCtx = {
     projectName: project.slug,
     projectSlug: project.slug,
-    timeBudgetSeconds: project.autonomyConfig.timeBudget,
+    timeBudgetSeconds: turnTimeBudget,
     developerName: config.developerName,
     context: maestro.context,
     state: maestro.state.raw,
@@ -234,6 +370,7 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
       body: f.commentBody,
       postedAt: f.postedAt,
     })),
+    ...(input.continuation ? { continuation: input.continuation } : {}),
   }
   const orientationMode = isOrientationModeFromContext(promptCtx)
   const prompt = buildSessionPrompt(promptCtx)
@@ -270,7 +407,7 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
   const runResult = await runClaudeSession({
     cwd: workingRoot,
     prompt,
-    timeBudgetSeconds: project.autonomyConfig.timeBudget,
+    timeBudgetSeconds: turnTimeBudget,
     logPath,
     claudeBin: input.claudeBin,
   })
@@ -692,6 +829,52 @@ function parseNeverTouchSection(contextMd: string): string[] {
     .filter((s): s is string => s !== null && s.length > 0 && !/^_.*_$/.test(s))
 }
 
+// ─── Phase 4 / Sub 2: soft reset between continuation turns ─────────
+
+/**
+ * Carry .maestro/ across a continuation boundary. Turn N produced commits
+ * on a feature branch (already pushed and PR-opened). Turn N+1 should
+ * start from a clean base branch but still see the agent's updated
+ * state.md / context.md / journal — otherwise the next turn would pick
+ * up the SAME task turn N just finished.
+ *
+ * Steps:
+ *   1. Capture .maestro/ from the current working tree (turn N's branch tip).
+ *   2. Switch to the base branch and reset to origin/<base>.
+ *   3. Replace .maestro/ in the working tree with the captured copy.
+ *   4. The next turn's agent will commit those .maestro/ updates as part
+ *      of its own branch.
+ *
+ * Throws if the working dir isn't a git repo or the base branch doesn't
+ * exist; the caller catches and stops continuation in that case.
+ */
+async function softResetForNextTurn(workingRoot: string, baseBranch: string): Promise<void> {
+  const { cp, mkdtemp } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+  const { join: joinPath } = await import('node:path')
+  const maestroPath = joinPath(workingRoot, '.maestro')
+  if (!existsSync(maestroPath)) return
+
+  const tmp = await mkdtemp(joinPath(tmpdir(), 'maestro-soft-reset-'))
+  const tmpMaestro = joinPath(tmp, '.maestro')
+  await cp(maestroPath, tmpMaestro, { recursive: true })
+
+  try {
+    const git = simpleGit(workingRoot)
+    await git.fetch(['origin', baseBranch])
+    await git.checkout(baseBranch)
+    await git.reset(['--hard', `origin/${baseBranch}`])
+    // Replace .maestro/ with the snapshot. Reset already removed any
+    // uncommitted changes; this writes the carried-over copy on top of
+    // whatever .maestro/ shipped on base.
+    await rm(maestroPath, { recursive: true, force: true })
+    await cp(tmpMaestro, maestroPath, { recursive: true })
+    logger.info({ workingRoot, baseBranch }, 'continuation: soft reset complete')
+  } finally {
+    await rm(tmp, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
 // ─── PR feedback marking ─────────────────────────────────────────────
 
 interface MarkFeedbackFromJournalInput {
@@ -758,6 +941,7 @@ export {
   workingDirFor,
   deriveTaskFromState,
   parseNeverTouchSection,
+  softResetForNextTurn,
   CACHE_DIRS,
 }
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -37,6 +37,16 @@ export const FIXUP_TURN_BUDGET_SECONDS = 15 * 60
 
 export const DEFAULT_QUALITY_GATES: QualityGate[] = ['test', 'lint', 'typecheck']
 
+/** 15 minutes. Don't spawn a continuation turn with less budget than this. */
+export const DEFAULT_MIN_TIME_FOR_CONTINUATION_SECONDS = 15 * 60
+
+/**
+ * Per-turn safety margin we subtract from "remaining budget" when deciding
+ * whether to continue and what budget to give the next turn. Covers gate
+ * runs, push, PR creation, and a small grace.
+ */
+export const CONTINUATION_TURN_OVERHEAD_SECONDS = 60
+
 export const DEFAULT_AUTONOMY_CONFIG: ProjectAutonomyConfig = {
   level: 'pr-only',
   schedule: '0 */6 * * *',
@@ -56,6 +66,10 @@ export const DEFAULT_AUTONOMY_CONFIG: ProjectAutonomyConfig = {
   // enables per project after manual sessions prove the project is healthy.
   scheduledEnabled: false,
   priority: 'normal',
+  // Phase 4 / Sub 2: opt-in by default to keep token consumption predictable
+  // until the developer validates per project. See ADR-024.
+  continueUntilBudget: false,
+  minTimeForContinuation: DEFAULT_MIN_TIME_FOR_CONTINUATION_SECONDS,
 }
 
 // ─── Scheduling ──────────────────────────────────────────────────────

--- a/packages/shared/src/prompt-templates.ts
+++ b/packages/shared/src/prompt-templates.ts
@@ -60,6 +60,21 @@ export interface SessionPromptContext {
    * the agent can locate the change.
    */
   pendingPrFeedback?: ReadonlyArray<PendingPrFeedbackEntry>
+  /**
+   * Phase 4 / Sub 2: marks this prompt as a continuation turn. When set,
+   * the prompt grows a CONTINUATION preamble that tells the agent which
+   * turn this is, which PRs the previous turns produced, and that the
+   * state.md it sees has already been updated by an earlier turn.
+   */
+  continuation?: ContinuationContext
+}
+
+export interface ContinuationContext {
+  /** This is turn N (>=2) of the same Maestro session. */
+  turnNumber: number
+  /** PR numbers opened by previous turns. May be empty if those turns
+   *  ran but produced no PR (orientation, no-changes). */
+  previousPrNumbers: number[]
 }
 
 export interface PendingPrFeedbackEntry {
@@ -305,6 +320,26 @@ Start by acknowledging your task. Then proceed.
 
 function buildPreamble(ctx: SessionPromptContext): string {
   const parts: string[] = []
+
+  if (ctx.continuation) {
+    const c = ctx.continuation
+    const prList = c.previousPrNumbers.length > 0
+      ? c.previousPrNumbers.map((n) => `#${n}`).join(', ')
+      : '_(none — previous turns ran but produced no PRs)_'
+    parts.push(
+      [
+        '== CONTINUATION ==',
+        '',
+        `This is turn ${c.turnNumber} of the same Maestro session. Previous turns`,
+        `produced PRs: ${prList}. The state.md you see below has already been`,
+        'updated by an earlier turn — your task list reflects what is left to do.',
+        '',
+        'Pick the next concrete task and proceed normally. Open your own PR on',
+        'a fresh feature branch (the branch from the previous turn is already',
+        'pushed and visible to GitHub; do not commit to it).',
+      ].join('\n'),
+    )
+  }
 
   if (ctx.isOrientationOnly) {
     parts.push(

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -54,6 +54,14 @@ export const ProjectAutonomyConfigSchema = z.object({
   scheduledEnabled: z.boolean().default(false),
   // Phase 2: cost-throttling priority hint. See skip rule E.
   priority: ProjectPrioritySchema.default('normal'),
+  // Phase 4 / Sub 2: opt-in session continuation. When true, after a
+  // successful PR is opened (or auto-merged), the worker spawns another
+  // Claude turn on the updated state.md if budget remains. See ADR-024.
+  continueUntilBudget: z.boolean().default(false),
+  // Don't continue if remaining budget falls below this many seconds.
+  // 15 min default — short enough that a quick task still has room,
+  // long enough to avoid spawning a turn that would die mid-flight.
+  minTimeForContinuation: z.number().int().positive().default(900),
 })
 
 // ─── Project ─────────────────────────────────────────────────────────
@@ -212,6 +220,32 @@ export const BriefingSchema = z.object({
   sentAt: z.string().datetime(),
   content: z.string(),
   tgMessageId: z.string().nullable(),
+})
+
+// ─── Phase 4 / Sub 2: session turns ──────────────────────────────────
+
+export const SessionTurnStatusSchema = z.enum([
+  'completed',
+  'completed-no-changes',
+  'quality-gate-failed',
+  'timed-out',
+  'failed',
+  'cancelled',
+])
+
+export const SessionTurnSchema = z.object({
+  id: z.number().int().positive(),
+  sessionId: z.string().min(1),
+  turnNumber: z.number().int().positive(),
+  branchName: z.string().nullable(),
+  prNumber: z.number().int().positive().nullable(),
+  prUrl: z.string().url().nullable(),
+  status: SessionTurnStatusSchema,
+  costCents: z.number().int().nonnegative().nullable(),
+  startedAt: z.string().datetime(),
+  endedAt: z.string().datetime().nullable(),
+  terminationCause: TerminationCauseSchema.nullable(),
+  notes: z.string().nullable(),
 })
 
 // ─── Phase 4: PR feedback loop ───────────────────────────────────────

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -24,6 +24,8 @@ import type {
   ScheduledRunActionSchema,
   ScheduleSkipReasonSchema,
   PrFeedbackSchema,
+  SessionTurnSchema,
+  SessionTurnStatusSchema,
 } from './schemas.js'
 import type { z } from 'zod'
 import type { PROJECT_STACKS } from './constants.js'
@@ -127,3 +129,7 @@ export type ScheduledRun = z.infer<typeof ScheduledRunSchema>
 
 // Phase 4: PR feedback loop.
 export type PrFeedback = z.infer<typeof PrFeedbackSchema>
+
+// Phase 4 / Sub 2: session turns.
+export type SessionTurnStatus = z.infer<typeof SessionTurnStatusSchema>
+export type SessionTurn = z.infer<typeof SessionTurnSchema>


### PR DESCRIPTION
Closes #41. Part of #39.

## Summary
- New autonomy.json fields: `continueUntilBudget` (default `false`) + `minTimeForContinuation` (default 900s)
- Worker loops on Claude turns within one logical session when the project opts in, until state.md has no more tasks or budget falls below the floor
- Each turn opens its own PR. New `session_turns` table records branch / PR / cost / status per turn; the parent session row's `pr_number` continues to reflect the most recent turn
- `softResetForNextTurn` snapshots `.maestro/`, hard-resets the working tree to `origin/<base>`, and restores `.maestro/` uncommitted — so the next turn sees the agent's updated state.md without inheriting the previous branch's commits
- Continuation prompt grows a `== CONTINUATION ==` preamble with turn number and previous PR numbers
- Per-turn budget = `remaining − CONTINUATION_TURN_OVERHEAD_SECONDS` so a turn isn't given more time than it can use
- ADR-024 documents the design (in particular the snapshot-restore rationale) and the subscription cost impact (~N× tokens for N turns)

## Test plan
- [x] `pnpm exec vitest run src/test/continuation.test.ts` — 5/5 pass (SessionTurnRepository CRUD, CONTINUATION preamble, softResetForNextTurn against a real local git repo)
- [x] `pnpm exec vitest run` — full conductor suite 94/94 pass
- [x] `pnpm -r build` — typechecks across all packages
- [x] `pnpm exec eslint . --max-warnings=0` — clean
- [ ] Live multi-turn smoke test once it lands: enable on the AIFlowo test project, run a session with 3+ tasks, verify multiple PRs open in one session