### PR TITLE
fix(worker): detect existing open PR for branch instead of 422-ing on create

### DIFF
--- a/packages/conductor/src/test/worker.test.ts
+++ b/packages/conductor/src/test/worker.test.ts
@@ -145,7 +145,9 @@ interface FakeGitHub extends GitHubClient {
   merged: { prNumber: number; method?: string }[]
 }
 
-function fakeGitHub(opts: { mergeBlocked?: boolean } = {}): FakeGitHub {
+function fakeGitHub(
+  opts: { mergeBlocked?: boolean; existingPrForBranch?: string; existingPrNumber?: number } = {},
+): FakeGitHub {
   const created: CreatePullRequestInput[] = []
   const labelsAdded: AddLabelsInput[] = []
   const merged: { prNumber: number; method?: string }[] = []
@@ -179,6 +181,22 @@ function fakeGitHub(opts: { mergeBlocked?: boolean } = {}): FakeGitHub {
       labelsAdded.push(req)
     },
     async listOpenPullRequests(_repo: RepoCoords) {
+      if (opts.existingPrForBranch) {
+        return [
+          {
+            number: opts.existingPrNumber ?? 99,
+            url: `https://example.test/pr/${opts.existingPrNumber ?? 99}`,
+            title: 'existing PR',
+            body: '',
+            status: 'open' as const,
+            branchName: opts.existingPrForBranch,
+            baseBranch: 'main',
+            createdAt: new Date().toISOString(),
+            mergedAt: null,
+            sessionId: null,
+          },
+        ]
+      }
       return []
     },
     async verifyScopes() {
@@ -353,6 +371,45 @@ describe('runSession (integration)', () => {
     expect(result.prNumber).toBe(42)
     expect(gh.merged).toHaveLength(1)
     expect(result.notes).toContain('auto-merge blocked')
+  }, 60_000)
+
+  it('agent reuses an existing PR branch — worker reuses the open PR instead of 422-ing', async () => {
+    harness = await setupHarness('all-good')
+    const { db, config, slug } = harness
+    const projects = new ProjectRepository(db.db)
+    const project = projects.findBySlug(slug)
+    if (!project) throw new Error('project missing')
+
+    const branch = `maestro/${slug}/auth-routing-fix`
+    // Pre-seed an open PR for this branch — simulates "agent is addressing
+    // PR feedback by adding commits to the existing PR's branch", which is
+    // the natural workflow for the PR-feedback loop. Without the
+    // detect-existing-PR check in worker.ts, GitHub would 422 on create.
+    const gh = fakeGitHub({ existingPrForBranch: branch, existingPrNumber: 99 })
+    process.env['MAESTRO_MOCK_INLINE'] = JSON.stringify({
+      files: { 'README.md': '# Fixture\n\nAddressed feedback.\n' },
+      branch,
+      commitMessage: '[#99] refactor: address feedback',
+      stateBody:
+        '# Current State\n\n## Focus\nx.\n\n## Next Concrete Tasks\n- [ ] x\n\n## Blockers\n\n_(none)_\n\n## Recent Context\n\nx.\n\n## Notes\n\n',
+      journalFilename: '2026-05-08-09-00-00.md',
+      journalBody:
+        '# Session\n\n## Goal\nAddressed PR #99 feedback (logger).\n\n## What I Did\nReplaced consoles.\n',
+    })
+
+    const result = await runSession({
+      db: db.db,
+      config,
+      project,
+      claudeBin: MOCK_CLAUDE,
+      githubClient: gh,
+      skipClaudeProbe: true,
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.prNumber).toBe(99) // existing PR, not a new 42
+    expect(gh.created).toHaveLength(0) // never tried to create
+    expect(result.notes ?? '').toContain('commits added to existing PR')
   }, 60_000)
 
   it('refuses to run a second session for the same project (lock)', async () => {

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -37,6 +37,7 @@ import {
   isOrientationModeFromContext,
   type ContinuationContext,
   type Project,
+  type PullRequest,
   type SessionStatus,
   type SessionResult,
   type QualityGate,
@@ -621,17 +622,41 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
     journalRef,
   ].join('\n')
 
-  const pr = await githubClient.createPullRequest({
-    repo,
-    branchName: branch,
-    baseBranch,
-    title,
-    body,
-    draft:
-      project.autonomyConfig.level === 'draft-only' ||
-      project.autonomyConfig.github.draftByDefault,
-    labels: project.autonomyConfig.github.prLabels,
+  // If the agent reused an existing branch (e.g. addressing PR feedback by
+  // adding commits to the open PR's branch — which is what a developer would
+  // do), GitHub returns 422 on createPullRequest because a PR already exists
+  // for that head ref. The push above already updated that PR with the new
+  // commits, so we just need to recognise the situation and proceed without
+  // creating a duplicate. Without this check the 422 throws out of the worker
+  // before baseFinalize runs, which means PR-feedback rows never get marked
+  // processed and the next session sees the same feedback again.
+  let pr: PullRequest
+  let prAlreadyExisted = false
+  const openPrs = await githubClient.listOpenPullRequests(repo).catch((err) => {
+    logger.warn({ err }, 'could not pre-check open PRs; will attempt create')
+    return [] as PullRequest[]
   })
+  const existing = openPrs.find((p) => p.branchName === branch)
+  if (existing) {
+    pr = existing
+    prAlreadyExisted = true
+    logger.info(
+      { prNumber: pr.number, branch },
+      'pr-manager: branch already has an open PR — added commits to existing PR',
+    )
+  } else {
+    pr = await githubClient.createPullRequest({
+      repo,
+      branchName: branch,
+      baseBranch,
+      title,
+      body,
+      draft:
+        project.autonomyConfig.level === 'draft-only' ||
+        project.autonomyConfig.github.draftByDefault,
+      labels: project.autonomyConfig.github.prLabels,
+    })
+  }
 
   if (project.autonomyConfig.level === 'full') {
     const merge = await githubClient.mergePullRequest({
@@ -662,7 +687,7 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
 
   return baseFinalize('completed', {
     prNumber: pr.number,
-    notes: pr.url,
+    notes: prAlreadyExisted ? `${pr.url} (commits added to existing PR)` : pr.url,
   })
 }
 


### PR DESCRIPTION
## Summary
- When the agent reuses an existing branch (e.g. addressing PR feedback by adding commits to the open PR's branch — the natural developer workflow), GitHub returns 422 on \`createPullRequest\`.
- The 422 was throwing out of \`runSessionInner\` before \`baseFinalize\` ran, which meant \`markFeedbackFromNewJournal\` never fired and the next session saw the same feedback still pending.
- Worker now lists open PRs first; if the branch already has one, it skips the create and reuses the existing PR for the rest of the flow (auto-merge for \`level: full\`, finalize, mark feedback processed).
- Success notes say "commits added to existing PR" so the developer can tell from session output that the PR was extended, not newly opened.

## Symptom that prompted this
Real session: agent addressed a "use a logger service globally" comment by replacing 39 \`console.*\` calls. Pushed clean commit on the existing PR branch. Worker called \`createPullRequest\` → 422 → exception. \`maestro feedback <slug>\` still showed the comment as pending despite the agent having addressed it.

## Test plan
- [x] New integration test: \`agent reuses an existing PR branch — worker reuses the open PR instead of 422-ing\` — pre-seeds an existing open PR via the fakeGitHub mock, asserts \`createPullRequest\` is never called and the existing PR number is used
- [x] \`pnpm exec vitest run\` — 95/95 pass
- [x] \`pnpm exec eslint . --max-warnings=0\` — clean