### PR TITLE
[#55] feat(dashboard): PR feedback page + badge on ProjectDetail

### DIFF
--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -17,6 +17,7 @@ import {
   ScheduledRunSchema,
   WeekdaySchema,
   ProjectPrioritySchema,
+  PrFeedbackSchema,
 } from '@maestro/shared'
 
 // ─── Common ──────────────────────────────────────────────────────────
@@ -155,6 +156,13 @@ export const QueueResponseSchema = z.object({
 
 export const ListSkipsResponseSchema = z.object({
   skips: z.array(ScheduledRunSchema),
+})
+
+// ─── PR feedback (Phase 4 / Sub 1) ───────────────────────────────────
+
+export const GetProjectFeedbackResponseSchema = z.object({
+  pending: z.array(PrFeedbackSchema),
+  pendingCount: z.number().int().nonnegative(),
 })
 
 // ─── Route registry ──────────────────────────────────────────────────

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -22,6 +22,7 @@ import type {
   PauseProjectBodySchema,
   QueueResponseSchema,
   ListSkipsResponseSchema,
+  GetProjectFeedbackResponseSchema,
 } from './routes.js'
 
 export type HealthResponse = z.infer<typeof HealthResponseSchema>
@@ -49,3 +50,4 @@ export type UpdateScheduleBody = z.infer<typeof UpdateScheduleBodySchema>
 export type PauseProjectBody = z.infer<typeof PauseProjectBodySchema>
 export type QueueResponse = z.infer<typeof QueueResponseSchema>
 export type ListSkipsResponse = z.infer<typeof ListSkipsResponseSchema>
+export type GetProjectFeedbackResponse = z.infer<typeof GetProjectFeedbackResponseSchema>

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -14,6 +14,7 @@ import { stat } from 'node:fs/promises'
 import { createReadStream } from 'node:fs'
 import {
   CostAggregationsResponseSchema,
+  GetProjectFeedbackResponseSchema,
   HealthResponseSchema,
   ListProjectsResponseSchema,
   ListScheduleResponseSchema,
@@ -127,10 +128,11 @@ export function buildServer(deps: ServerDeps): Hono {
     if (!project) {
       return c.json({ error: { code: 'PROJECT_NOT_FOUND', message: 'Unknown project' } }, 404)
     }
-    return c.json({
+    const body = GetProjectFeedbackResponseSchema.parse({
       pending: feedback.pendingForProject(project.id),
       pendingCount: feedback.pendingCount(project.id),
     })
+    return c.json(body)
   })
 
   app.get('/api/sessions', (c) => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import { Overview } from './pages/Overview'
 import { ProjectDetail } from './pages/ProjectDetail'
+import { ProjectFeedback } from './pages/ProjectFeedback'
 import { Sessions } from './pages/Sessions'
 import { SessionDetail } from './pages/SessionDetail'
 import { PRs } from './pages/PRs'
@@ -16,6 +17,7 @@ export function App() {
       <Route element={<Layout />}>
         <Route index element={<Overview />} />
         <Route path="projects/:slug" element={<ProjectDetail />} />
+        <Route path="projects/:slug/feedback" element={<ProjectFeedback />} />
         <Route path="sessions" element={<Sessions />} />
         <Route path="sessions/:id" element={<SessionDetail />} />
         <Route path="prs" element={<PRs />} />

--- a/packages/dashboard/src/pages/ProjectDetail.tsx
+++ b/packages/dashboard/src/pages/ProjectDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import type {
   GetProjectResponse,
+  GetProjectFeedbackResponse,
   ListScheduleResponse,
   ListSessionsResponse,
   ListSkipsResponse,
@@ -16,6 +17,7 @@ export function ProjectDetail() {
   const [project, setProject] = useState<GetProjectResponse | null>(null)
   const [sessions, setSessions] = useState<ListSessionsResponse | null>(null)
   const [costs, setCosts] = useState<CostAggregationsResponse | null>(null)
+  const [feedback, setFeedback] = useState<GetProjectFeedbackResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [triggerState, setTriggerState] = useState<
     { kind: 'idle' } | { kind: 'pending' } | { kind: 'ok'; jobId: string } | { kind: 'err'; message: string }
@@ -27,11 +29,17 @@ export function ProjectDetail() {
     void Promise.all([
       api.get<GetProjectResponse>(`/api/projects/${encodeURIComponent(slug)}`),
       api.get<CostAggregationsResponse>('/api/costs'),
+      api
+        .get<GetProjectFeedbackResponse>(
+          `/api/projects/${encodeURIComponent(slug)}/feedback`,
+        )
+        .catch(() => ({ pending: [], pendingCount: 0 }) as GetProjectFeedbackResponse),
     ])
-      .then(async ([p, c]) => {
+      .then(async ([p, c, f]) => {
         if (cancelled) return
         setProject(p)
         setCosts(c)
+        setFeedback(f)
         const s = await api.get<ListSessionsResponse>(
           `/api/sessions?projectId=${encodeURIComponent(p.project.id)}&limit=20`,
         )
@@ -85,6 +93,15 @@ export function ProjectDetail() {
           <span className="pill pill-amber">{p.autonomyConfig.level}</span>
           <span className="pill">budget {Math.round(p.autonomyConfig.timeBudget / 60)}m</span>
           <span className="pill font-mono">{p.autonomyConfig.schedule}</span>
+          {feedback && feedback.pendingCount > 0 ? (
+            <Link
+              to={`/projects/${encodeURIComponent(p.slug)}/feedback`}
+              className="pill pill-amber hover:bg-amber-400/30"
+              title="Reviewer comments waiting to be folded into the next session"
+            >
+              Feedback ({feedback.pendingCount})
+            </Link>
+          ) : null}
           <button
             type="button"
             onClick={() => void triggerNow()}

--- a/packages/dashboard/src/pages/ProjectFeedback.tsx
+++ b/packages/dashboard/src/pages/ProjectFeedback.tsx
@@ -1,0 +1,120 @@
+// Phase 4.5 / Sub 4.5.2 — surfaces unprocessed PR comments that will be
+// fed into the next session for this project. The data comes from the
+// `pr_feedback` table populated by Sub 1; this page is read-only.
+
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import type { GetProjectFeedbackResponse, GetProjectResponse } from '@maestro/api'
+import { useApi } from '../hooks/useApi'
+import { formatDateTime } from '../lib/format'
+
+export function ProjectFeedback() {
+  const { slug } = useParams<{ slug: string }>()
+  const api = useApi()
+  const [project, setProject] = useState<GetProjectResponse | null>(null)
+  const [feedback, setFeedback] = useState<GetProjectFeedbackResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+    void Promise.all([
+      api.get<GetProjectResponse>(`/api/projects/${encodeURIComponent(slug)}`),
+      api.get<GetProjectFeedbackResponse>(
+        `/api/projects/${encodeURIComponent(slug)}/feedback`,
+      ),
+    ])
+      .then(([p, f]) => {
+        if (cancelled) return
+        setProject(p)
+        setFeedback(f)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'unknown error')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [api, slug])
+
+  if (error) return <ErrorCard message={error} />
+  if (!project || !feedback) return <Skeleton />
+
+  const p = project.project
+  const repoBase = p.repoUrl.replace(/\.git$/, '')
+
+  return (
+    <section className="mx-auto max-w-4xl space-y-6">
+      <header>
+        <Link
+          to={`/projects/${encodeURIComponent(p.slug)}`}
+          className="text-xs text-amber-400 hover:underline"
+        >
+          ← {p.slug}
+        </Link>
+        <h2 className="mt-2 font-mono text-lg text-white">PR feedback</h2>
+        <p className="mt-1 text-sm text-navy-400">
+          Unprocessed reviewer comments on this project&apos;s open Maestro PRs.
+          They are folded into the next session&apos;s prompt automatically. When
+          the agent addresses one in its journal entry (e.g.{' '}
+          <span className="font-mono">addressed PR #42 feedback</span>) the
+          worker marks it processed.
+        </p>
+      </header>
+
+      {feedback.pending.length === 0 ? (
+        <div className="panel px-5 py-6 text-sm text-navy-400">
+          No pending feedback. Comments from{' '}
+          <span className="font-mono">aaryansinha16</span> on open Maestro PRs
+          will appear here within minutes of being posted.
+        </div>
+      ) : (
+        <div className="panel divide-y divide-navy-700/70">
+          {feedback.pending.map((f) => (
+            <article key={f.id} className="px-5 py-4">
+              <header className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
+                <div className="flex items-center gap-2">
+                  <a
+                    href={`${repoBase}/pull/${f.prNumber}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-mono text-amber-300 hover:underline"
+                  >
+                    PR #{f.prNumber}
+                  </a>
+                  <span className="font-mono text-xs text-navy-400">{f.prBranch}</span>
+                </div>
+                <div className="text-xs text-navy-400">
+                  <span className="text-navy-100">{f.commentAuthor}</span> ·{' '}
+                  {formatDateTime(f.postedAt)}
+                </div>
+              </header>
+              <pre className="mt-3 whitespace-pre-wrap break-words text-sm text-navy-100">
+                {f.commentBody}
+              </pre>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Skeleton() {
+  return (
+    <section className="mx-auto max-w-4xl space-y-4">
+      <div className="panel h-16 animate-pulse" />
+      <div className="panel h-40 animate-pulse" />
+    </section>
+  )
+}
+
+function ErrorCard({ message }: { message: string }) {
+  return (
+    <section className="mx-auto max-w-3xl">
+      <div className="panel border-danger/40 bg-danger/10 px-5 py-4 text-sm text-danger">
+        {message}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #55. Part of #52.

## Summary
- New page \`pages/ProjectFeedback.tsx\` at \`/projects/:slug/feedback\` — lists pending PR comments populated by Sub 1's worker sync.
- ProjectDetail header gains a "Feedback (N)" pill that links through when \`pendingCount > 0\`.
- Adds \`GetProjectFeedbackResponseSchema\` to \`@maestro/api\` for type-safe response shape; server now \`.parse()\`s its response through it, matching existing \`/api/queue\` and \`/api/skips\` pattern.

## Test plan
- [x] \`pnpm -r build\` — typechecks across all packages
- [x] \`pnpm exec eslint . --max-warnings=0\` — clean
- [x] \`pnpm -r test\` — 95/95 pass
- [ ] Manual: post a comment on aiflowo PR #48, run a session, navigate to ProjectDetail → Feedback badge appears → clicking opens the new page with the comment