### PR TITLE
[#57] feat(dashboard): pause button + autonomy editor

### DIFF
--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -165,6 +165,38 @@ export const GetProjectFeedbackResponseSchema = z.object({
   pendingCount: z.number().int().nonnegative(),
 })
 
+// ─── Autonomy editing (Phase 4.5 / Sub 4.5.3) ────────────────────────
+
+// Fields editable via /api/projects/:slug/autonomy. Schedule-side fields
+// (schedule, skipDays, maxSessionsPerDay, priority) and the
+// scheduledEnabled flag are intentionally excluded — they go through
+// /api/projects/:slug/schedule and /scheduling/{enable,disable}.
+//
+// `level: 'paused'` is accepted here for the "persistently paused"
+// semantic; the pause endpoint at /pause is for transient pauses
+// reflected in auto_paused_at.
+export const UpdateAutonomyBodySchema = z.object({
+  level: z.enum(['full', 'pr-only', 'draft-only', 'paused']).optional(),
+  timeBudget: z.number().int().positive().optional(),
+  qualityGates: z
+    .array(z.enum(['test', 'lint', 'typecheck', 'build']))
+    .optional(),
+  branches: z
+    .object({
+      base: z.string().min(1).optional(),
+      prefix: z.string().min(1).optional(),
+    })
+    .optional(),
+  github: z
+    .object({
+      prLabels: z.array(z.string()).optional(),
+      draftByDefault: z.boolean().optional(),
+    })
+    .optional(),
+  continueUntilBudget: z.boolean().optional(),
+  minTimeForContinuation: z.number().int().positive().optional(),
+})
+
 // ─── Route registry ──────────────────────────────────────────────────
 
 // A typed catalogue of every route, useful to the dashboard's fetch wrapper
@@ -193,6 +225,8 @@ export const ROUTES = {
   triggerProject: { method: 'POST', path: '/api/projects/:slug/trigger' },
   // Phase 4 / Sub 1.
   getProjectFeedback: { method: 'GET', path: '/api/projects/:slug/feedback' },
+  // Phase 4.5 / Sub 4.5.3.
+  updateAutonomy: { method: 'POST', path: '/api/projects/:slug/autonomy' },
 } as const
 
 export type RouteKey = keyof typeof ROUTES

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -23,6 +23,7 @@ import type {
   QueueResponseSchema,
   ListSkipsResponseSchema,
   GetProjectFeedbackResponseSchema,
+  UpdateAutonomyBodySchema,
 } from './routes.js'
 
 export type HealthResponse = z.infer<typeof HealthResponseSchema>
@@ -51,3 +52,4 @@ export type PauseProjectBody = z.infer<typeof PauseProjectBodySchema>
 export type QueueResponse = z.infer<typeof QueueResponseSchema>
 export type ListSkipsResponse = z.infer<typeof ListSkipsResponseSchema>
 export type GetProjectFeedbackResponse = z.infer<typeof GetProjectFeedbackResponseSchema>
+export type UpdateAutonomyBody = z.infer<typeof UpdateAutonomyBodySchema>

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -9,6 +9,7 @@ import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { logger as honoLogger } from 'hono/logger'
 import { HTTPException } from 'hono/http-exception'
+import { ZodError } from 'zod'
 import { existsSync } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { createReadStream } from 'node:fs'
@@ -22,6 +23,7 @@ import {
   ListSkipsResponseSchema,
   PauseProjectBodySchema,
   QueueResponseSchema,
+  UpdateAutonomyBodySchema,
   UpdateScheduleBodySchema,
 } from '@maestro/api'
 import {
@@ -86,6 +88,21 @@ export function buildServer(deps: ServerDeps): Hono {
 
   app.onError((err, c) => {
     if (err instanceof HTTPException) return err.getResponse()
+    // ZodError → 400. Catches request-body validation failures from any
+    // handler that calls Schema.parse() on user input (which is most of
+    // them). Without this they bubble to the generic 500 below.
+    if (err instanceof ZodError) {
+      return c.json(
+        {
+          error: {
+            code: 'VALIDATION_FAILED',
+            message: 'Request validation failed',
+            issues: err.issues,
+          },
+        },
+        400,
+      )
+    }
     if (isMaestroError(err)) {
       logger.error({ err }, 'request failed with MaestroError')
       return c.json(
@@ -357,6 +374,34 @@ export function buildServer(deps: ServerDeps): Hono {
       ...body,
     })
     projects.updateAutonomyConfig(slug, merged)
+    deps.scheduler?.reconcileNow()
+    return c.json({ ok: true })
+  })
+
+  app.post('/api/projects/:slug/autonomy', async (c) => {
+    const slug = c.req.param('slug')
+    const project = projects.findBySlug(slug)
+    if (!project) return notFoundProject(c, slug)
+    const raw = (await c.req.json().catch(() => ({}))) as unknown
+    const body = UpdateAutonomyBodySchema.parse(raw)
+    // Deep-merge: nested objects (branches, github) should patch, not
+    // replace, so the caller can change just one nested field at a time.
+    const merged = AutonomyFileSchema.parse({
+      ...project.autonomyConfig,
+      ...body,
+      branches: {
+        ...project.autonomyConfig.branches,
+        ...(body.branches ?? {}),
+      },
+      github: {
+        ...project.autonomyConfig.github,
+        ...(body.github ?? {}),
+      },
+    })
+    projects.updateAutonomyConfig(slug, merged)
+    // The scheduler doesn't track these fields, but reconcileNow is cheap
+    // and keeps cron-registration consistent if `level` flipped to
+    // 'paused' (skip rule fires on the next tick regardless).
     deps.scheduler?.reconcileNow()
     return c.json({ ok: true })
   })

--- a/packages/conductor/src/test/server-autonomy.test.ts
+++ b/packages/conductor/src/test/server-autonomy.test.ts
@@ -1,0 +1,126 @@
+// Phase 4.5 / Sub 4.5.3 — POST /api/projects/:slug/autonomy.
+//
+// Validates: partial bodies round-trip through AutonomyFileSchema and
+// persist to the SQLite row; nested fields (branches, github) deep-merge
+// instead of replacing; invalid bodies return 400.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { openDatabase, type DbHandle } from '../db.js'
+import { ProjectRepository } from '../repositories.js'
+import { buildServer } from '../server.js'
+import { DEFAULT_AUTONOMY_CONFIG } from '@maestro/shared'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-server-autonomy-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+function addProject(slug: string) {
+  if (!h) throw new Error('harness missing')
+  const id = randomUUID()
+  new ProjectRepository(h.db.db).insert({
+    id,
+    slug,
+    repoUrl: `https://github.com/example/${slug}`,
+    autonomyConfig: { ...DEFAULT_AUTONOMY_CONFIG },
+  })
+  return id
+}
+
+function server() {
+  if (!h) throw new Error('harness missing')
+  return buildServer({
+    startedAt: Date.now(),
+    version: 'test',
+    db: h.db.db,
+    dataDir: h.root,
+    developerName: 'Tester',
+  })
+}
+
+function postAutonomy(slug: string, body: unknown) {
+  return server().request(`/api/projects/${slug}/autonomy`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/projects/:slug/autonomy', () => {
+  it('persists a partial body and leaves other fields alone', async () => {
+    addProject('p')
+    const res = await postAutonomy('p', {
+      level: 'full',
+      timeBudget: 3600,
+      continueUntilBudget: true,
+    })
+    expect(res.status).toBe(200)
+    if (!h) throw new Error('harness missing')
+    const project = new ProjectRepository(h.db.db).findBySlug('p')
+    expect(project?.autonomyConfig.level).toBe('full')
+    expect(project?.autonomyConfig.timeBudget).toBe(3600)
+    expect(project?.autonomyConfig.continueUntilBudget).toBe(true)
+    // Untouched fields retain defaults.
+    expect(project?.autonomyConfig.qualityGates).toEqual(
+      DEFAULT_AUTONOMY_CONFIG.qualityGates,
+    )
+    expect(project?.autonomyConfig.schedule).toBe(DEFAULT_AUTONOMY_CONFIG.schedule)
+  })
+
+  it('deep-merges nested branches + github objects', async () => {
+    addProject('p')
+    const res = await postAutonomy('p', {
+      branches: { base: 'develop' },
+      github: { draftByDefault: true },
+    })
+    expect(res.status).toBe(200)
+    if (!h) throw new Error('harness missing')
+    const project = new ProjectRepository(h.db.db).findBySlug('p')
+    // Patched fields take the new value:
+    expect(project?.autonomyConfig.branches.base).toBe('develop')
+    expect(project?.autonomyConfig.github.draftByDefault).toBe(true)
+    // Sibling fields inside the nested objects survive:
+    expect(project?.autonomyConfig.branches.prefix).toBe(
+      DEFAULT_AUTONOMY_CONFIG.branches.prefix,
+    )
+    expect(project?.autonomyConfig.github.prLabels).toEqual(
+      DEFAULT_AUTONOMY_CONFIG.github.prLabels,
+    )
+  })
+
+  it('rejects an invalid level', async () => {
+    addProject('p')
+    const res = await postAutonomy('p', { level: 'not-a-real-level' })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects negative timeBudget', async () => {
+    addProject('p')
+    const res = await postAutonomy('p', { timeBudget: -1 })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for unknown project', async () => {
+    const res = await postAutonomy('does-not-exist', { level: 'full' })
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/dashboard/src/components/AutonomyForm.tsx
+++ b/packages/dashboard/src/components/AutonomyForm.tsx
@@ -1,0 +1,281 @@
+// Phase 4.5 / Sub 4.5.3 — structured editor for ProjectAutonomyConfig.
+// Backs both the inline "Edit autonomy" toggle on ProjectDetail and the
+// onboarding wizard from 4.5.4. Schedule-side fields (schedule, skipDays,
+// maxSessionsPerDay, priority, scheduledEnabled) are intentionally NOT
+// edited here — they go through the /api/projects/:slug/schedule
+// endpoint (and the Schedule page surfaces toggles for them).
+
+import { useEffect, useState } from 'react'
+import type { UpdateAutonomyBody } from '@maestro/api'
+import type { ProjectAutonomyConfig } from '@maestro/shared'
+
+const LEVELS: ReadonlyArray<ProjectAutonomyConfig['level']> = [
+  'pr-only',
+  'draft-only',
+  'full',
+  'paused',
+]
+const GATES = ['test', 'lint', 'typecheck', 'build'] as const
+
+type Gate = (typeof GATES)[number]
+
+export interface AutonomyFormProps {
+  value: ProjectAutonomyConfig
+  onSubmit: (patch: UpdateAutonomyBody) => Promise<void>
+  onCancel?: () => void
+  /** Submit button label. Defaults to "Save". The wizard overrides this. */
+  submitLabel?: string
+}
+
+interface FormState {
+  level: ProjectAutonomyConfig['level']
+  timeBudgetMinutes: number
+  qualityGates: Set<Gate>
+  branchBase: string
+  branchPrefix: string
+  prLabels: string  // comma-separated
+  draftByDefault: boolean
+  continueUntilBudget: boolean
+  minTimeForContinuationMinutes: number
+}
+
+function toFormState(v: ProjectAutonomyConfig): FormState {
+  return {
+    level: v.level,
+    timeBudgetMinutes: Math.round(v.timeBudget / 60),
+    qualityGates: new Set(v.qualityGates as Gate[]),
+    branchBase: v.branches.base,
+    branchPrefix: v.branches.prefix,
+    prLabels: v.github.prLabels.join(', '),
+    draftByDefault: v.github.draftByDefault,
+    continueUntilBudget: v.continueUntilBudget,
+    minTimeForContinuationMinutes: Math.round(v.minTimeForContinuation / 60),
+  }
+}
+
+function fromFormState(s: FormState): UpdateAutonomyBody {
+  return {
+    level: s.level,
+    timeBudget: s.timeBudgetMinutes * 60,
+    qualityGates: [...s.qualityGates].sort(),
+    branches: {
+      base: s.branchBase.trim(),
+      prefix: s.branchPrefix.trim(),
+    },
+    github: {
+      prLabels: s.prLabels
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean),
+      draftByDefault: s.draftByDefault,
+    },
+    continueUntilBudget: s.continueUntilBudget,
+    minTimeForContinuation: s.minTimeForContinuationMinutes * 60,
+  }
+}
+
+export function AutonomyForm({
+  value,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save',
+}: AutonomyFormProps) {
+  const [state, setState] = useState<FormState>(() => toFormState(value))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setState(toFormState(value))
+  }, [value])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (state.timeBudgetMinutes < 1) {
+      setError('Time budget must be at least 1 minute.')
+      return
+    }
+    if (state.minTimeForContinuationMinutes < 1) {
+      setError('Min time for continuation must be at least 1 minute.')
+      return
+    }
+    setError(null)
+    setSubmitting(true)
+    try {
+      await onSubmit(fromFormState(state))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to save')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const toggleGate = (gate: Gate) => {
+    setState((s) => {
+      const next = new Set(s.qualityGates)
+      if (next.has(gate)) next.delete(gate)
+      else next.add(gate)
+      return { ...s, qualityGates: next }
+    })
+  }
+
+  return (
+    <form onSubmit={(e) => void submit(e)} className="grid grid-cols-1 gap-4 px-5 py-4 md:grid-cols-2">
+      <Field label="Autonomy level">
+        <select
+          value={state.level}
+          onChange={(e) =>
+            setState((s) => ({ ...s, level: e.target.value as ProjectAutonomyConfig['level'] }))
+          }
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 text-sm text-navy-100"
+        >
+          {LEVELS.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Time budget (minutes)">
+        <input
+          type="number"
+          min={1}
+          max={240}
+          value={state.timeBudgetMinutes}
+          onChange={(e) =>
+            setState((s) => ({ ...s, timeBudgetMinutes: Number(e.target.value) }))
+          }
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 text-sm text-navy-100"
+        />
+      </Field>
+
+      <Field label="Quality gates" className="md:col-span-2">
+        <div className="flex flex-wrap gap-3">
+          {GATES.map((g) => (
+            <label key={g} className="flex items-center gap-2 text-sm text-navy-100">
+              <input
+                type="checkbox"
+                checked={state.qualityGates.has(g)}
+                onChange={() => toggleGate(g)}
+              />
+              {g}
+            </label>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Base branch">
+        <input
+          type="text"
+          value={state.branchBase}
+          onChange={(e) => setState((s) => ({ ...s, branchBase: e.target.value }))}
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 font-mono text-sm text-navy-100"
+        />
+      </Field>
+
+      <Field label="Branch prefix">
+        <input
+          type="text"
+          value={state.branchPrefix}
+          onChange={(e) => setState((s) => ({ ...s, branchPrefix: e.target.value }))}
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 font-mono text-sm text-navy-100"
+        />
+      </Field>
+
+      <Field label="PR labels (comma-separated)" className="md:col-span-2">
+        <input
+          type="text"
+          value={state.prLabels}
+          onChange={(e) => setState((s) => ({ ...s, prLabels: e.target.value }))}
+          placeholder="maestro, automation"
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 text-sm text-navy-100"
+        />
+      </Field>
+
+      <Field label="Open PRs as draft by default">
+        <label className="flex items-center gap-2 text-sm text-navy-100">
+          <input
+            type="checkbox"
+            checked={state.draftByDefault}
+            onChange={(e) =>
+              setState((s) => ({ ...s, draftByDefault: e.target.checked }))
+            }
+          />
+          {state.draftByDefault ? 'draft' : 'open'}
+        </label>
+      </Field>
+
+      <Field label="Continue until budget exhausted">
+        <label className="flex items-center gap-2 text-sm text-navy-100">
+          <input
+            type="checkbox"
+            checked={state.continueUntilBudget}
+            onChange={(e) =>
+              setState((s) => ({ ...s, continueUntilBudget: e.target.checked }))
+            }
+          />
+          {state.continueUntilBudget ? 'enabled' : 'disabled'}
+        </label>
+      </Field>
+
+      <Field label="Min time for continuation (minutes)">
+        <input
+          type="number"
+          min={1}
+          max={240}
+          value={state.minTimeForContinuationMinutes}
+          onChange={(e) =>
+            setState((s) => ({
+              ...s,
+              minTimeForContinuationMinutes: Number(e.target.value),
+            }))
+          }
+          className="w-full rounded border border-navy-700 bg-navy-800 px-2 py-1 text-sm text-navy-100"
+        />
+      </Field>
+
+      {error ? (
+        <div className="md:col-span-2 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="md:col-span-2 flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded border border-amber-400/60 bg-amber-400/10 px-3 py-1 text-xs font-medium text-amber-200 transition hover:bg-amber-400/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+        {onCancel ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={submitting}
+            className="rounded border border-navy-700 px-3 py-1 text-xs text-navy-300 transition hover:border-navy-600"
+          >
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </form>
+  )
+}
+
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className={className}>
+      <div className="mb-1 text-xs uppercase tracking-wide text-navy-400">{label}</div>
+      {children}
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/ProjectDetail.tsx
+++ b/packages/dashboard/src/pages/ProjectDetail.tsx
@@ -7,9 +7,11 @@ import type {
   ListSessionsResponse,
   ListSkipsResponse,
   CostAggregationsResponse,
+  UpdateAutonomyBody,
 } from '@maestro/api'
 import { useApi } from '../hooks/useApi'
 import { formatDateTime, formatDuration, statusLabel } from '../lib/format'
+import { AutonomyForm } from '../components/AutonomyForm'
 
 export function ProjectDetail() {
   const { slug } = useParams<{ slug: string }>()
@@ -203,29 +205,15 @@ export function ProjectDetail() {
 
       <SchedulingPanel slug={p.slug} />
 
-      <div className="panel">
-        <header className="panel-header">
-          <h3 className="font-medium text-white">Configuration</h3>
-        </header>
-        <dl className="grid grid-cols-1 gap-3 px-5 py-4 text-sm md:grid-cols-2">
-          <Field label="Quality gates" value={p.autonomyConfig.qualityGates.join(', ') || '—'} />
-          <Field
-            label="Branch prefix"
-            value={p.autonomyConfig.branches.prefix}
-            mono
-          />
-          <Field label="Base branch" value={p.autonomyConfig.branches.base} mono />
-          <Field
-            label="PR labels"
-            value={p.autonomyConfig.github.prLabels.join(', ') || '—'}
-          />
-          <Field
-            label="Draft by default"
-            value={p.autonomyConfig.github.draftByDefault ? 'yes' : 'no'}
-          />
-          <Field label="Max sessions / day" value={String(p.autonomyConfig.maxSessionsPerDay)} />
-        </dl>
-      </div>
+      <ConfigurationPanel
+        project={p}
+        onSaved={async () => {
+          const next = await api.get<GetProjectResponse>(
+            `/api/projects/${encodeURIComponent(p.slug)}`,
+          )
+          setProject(next)
+        }}
+      />
 
       <p className="text-xs text-navy-400">
         Note: state.md and context.md live in the project's git repo (
@@ -235,6 +223,71 @@ export function ProjectDetail() {
         ). Edit them via git, not the dashboard.
       </p>
     </section>
+  )
+}
+
+function ConfigurationPanel({
+  project,
+  onSaved,
+}: {
+  project: GetProjectResponse['project']
+  onSaved: () => Promise<void> | void
+}) {
+  const api = useApi()
+  const [editing, setEditing] = useState(false)
+
+  const save = async (patch: UpdateAutonomyBody) => {
+    await api.post(`/api/projects/${encodeURIComponent(project.slug)}/autonomy`, patch)
+    await onSaved()
+    setEditing(false)
+  }
+
+  return (
+    <div className="panel">
+      <header className="panel-header">
+        <h3 className="font-medium text-white">Configuration</h3>
+        <button
+          type="button"
+          onClick={() => setEditing((v) => !v)}
+          className="text-xs text-amber-400 hover:underline"
+        >
+          {editing ? 'cancel' : 'edit autonomy'}
+        </button>
+      </header>
+      {editing ? (
+        <AutonomyForm
+          value={project.autonomyConfig}
+          onSubmit={save}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        <dl className="grid grid-cols-1 gap-3 px-5 py-4 text-sm md:grid-cols-2">
+          <Field label="Quality gates" value={project.autonomyConfig.qualityGates.join(', ') || '—'} />
+          <Field label="Branch prefix" value={project.autonomyConfig.branches.prefix} mono />
+          <Field label="Base branch" value={project.autonomyConfig.branches.base} mono />
+          <Field
+            label="PR labels"
+            value={project.autonomyConfig.github.prLabels.join(', ') || '—'}
+          />
+          <Field
+            label="Draft by default"
+            value={project.autonomyConfig.github.draftByDefault ? 'yes' : 'no'}
+          />
+          <Field
+            label="Max sessions / day"
+            value={String(project.autonomyConfig.maxSessionsPerDay)}
+          />
+          <Field
+            label="Continue until budget"
+            value={project.autonomyConfig.continueUntilBudget ? 'enabled' : 'disabled'}
+          />
+          <Field
+            label="Min time for continuation"
+            value={`${Math.round(project.autonomyConfig.minTimeForContinuation / 60)}m`}
+          />
+        </dl>
+      )}
+    </div>
   )
 }
 
@@ -306,6 +359,14 @@ function SchedulingPanel({ slug }: { slug: string }) {
     setSchedule(next)
   }
 
+  const pause = async () => {
+    const reason = window.prompt('Pause reason (will appear in scheduled-runs audit log):', 'manual pause from dashboard')
+    if (reason === null) return // cancelled
+    await api.post(`/api/projects/${encodeURIComponent(slug)}/pause`, { reason })
+    const next = await api.get<ListScheduleResponse>('/api/schedule')
+    setSchedule(next)
+  }
+
   return (
     <div className="panel">
       <header className="panel-header">
@@ -317,7 +378,14 @@ function SchedulingPanel({ slug }: { slug: string }) {
           >
             resume now
           </button>
-        ) : null}
+        ) : (
+          <button
+            onClick={() => void pause()}
+            className="text-xs text-navy-400 hover:text-amber-400 hover:underline"
+          >
+            pause
+          </button>
+        )}
       </header>
       <div className="grid grid-cols-1 gap-3 px-5 py-4 text-sm md:grid-cols-3">
         <div>


### PR DESCRIPTION
Closes #57. Part of #52.

## Summary
- Pause button on SchedulingPanel (prompts for reason, POSTs to existing /pause endpoint)
- "Edit autonomy" toggle on ProjectDetail's Configuration panel swaps in a structured form
- New \`POST /api/projects/:slug/autonomy\` endpoint with \`UpdateAutonomyBodySchema\` — partial body, deep-merges nested branches/github objects
- New \`components/AutonomyForm.tsx\` component (reused by 4.5.4)
- Drive-by: \`onError\` now converts ZodError → 400 with issues payload (was bubbling to 500)

## Test plan
- [x] 5 new conductor tests: partial persistence, deep-merge, invalid level → 400, negative timeBudget → 400, 404 unknown project
- [x] \`pnpm -r test\` — 100/100 pass
- [x] \`pnpm -r build\` — typechecks across all packages
- [x] \`pnpm exec eslint . --max-warnings=0\` — clean
- [ ] Manual: edit autonomy from dashboard, reload, confirm values persist; pause from dashboard, verify SchedulingPanel reflects auto-pause and skip rules fire on next tick