### PR TITLE
chore(dashboard): make dev proxy target follow MAESTRO_PORT

### DIFF
--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -1,19 +1,31 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+// Resolve the conductor's address for the dev-server proxy. Reads
+// VITE_API_PROXY_TARGET first (e.g. http://localhost:3001 when the
+// default port collides with another dev server), then falls back to
+// `http://localhost:${MAESTRO_PORT}` from the repo-root .env, then to
+// localhost:3000. Loading via Vite's `loadEnv` rather than `process.env`
+// directly so it picks up the same .env discovery the conductor uses.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, '../..', '')
+  const explicit = env.VITE_API_PROXY_TARGET
+  const port = env.MAESTRO_PORT
+  const target = explicit || (port ? `http://localhost:${port}` : 'http://localhost:3000')
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target,
+          changeOrigin: true,
+        },
       },
     },
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-  },
+    build: {
+      outDir: 'dist',
+      sourcemap: true,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- Vite dev proxy target was hard-coded to localhost:3000; when that port is occupied (another project's dev server, Docker), changing MAESTRO_PORT broke the dashboard silently.
- Now resolves: \`VITE_API_PROXY_TARGET\` → \`http://localhost:\${MAESTRO_PORT}\` (from repo-root .env via Vite loadEnv) → localhost:3000 default.

## Test plan
- [x] \`pnpm --filter @maestro/dashboard build\` — clean
- [x] Manual: with MAESTRO_PORT=3100 in .env, \`pnpm dev\` boots conductor on 3100 and dashboard proxies /api there correctly (verified during the port-conflict session)