### PR TITLE
[#62] feat(conductor): serve the static dashboard from the Hono app

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,10 +55,12 @@ curl https://maestro.<your-domain>/api/health
 # → { "status": "ok", "version": "0.0.0", "uptimeSeconds": 8, ... }
 ```
 
-The dashboard is served as a static build alongside the conductor in
-production. In Phase 0 the static assets are built but not yet wired into
-the Hono app (Phase 3 mounts them); for now, run the dashboard locally
-against the deployed conductor by exporting `VITE_API_BASE_URL`.
+The dashboard is served by the conductor itself (Phase 5): every
+non-`/api` GET serves the vite build with an index.html SPA fallback.
+The Docker image bakes the build at `/app/dashboard`; outside Docker the
+conductor looks for `MAESTRO_DASHBOARD_DIR`, then the repo-relative
+`packages/dashboard/dist`. Opening `https://maestro.<your-domain>/`
+should render the Overview page with no separate dashboard process.
 
 ## Updating
 

--- a/packages/conductor/src/index.ts
+++ b/packages/conductor/src/index.ts
@@ -3,6 +3,9 @@
 // off this module once their phases land.
 
 import { serve } from '@hono/node-server'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { loadConfig } from './config.js'
 import { openDatabase } from './db.js'
 import { buildServer } from './server.js'
@@ -83,6 +86,7 @@ async function main(): Promise<void> {
   })
   startBriefing({ db: dbHandle.db, config })
 
+  const dashboardDir = resolveDashboardDir()
   const app = buildServer({
     startedAt,
     version: PACKAGE_VERSION,
@@ -93,6 +97,7 @@ async function main(): Promise<void> {
     scheduler,
     schedulerTimezone: process.env['MAESTRO_TZ'] ?? 'UTC',
     ...(config.githubToken ? { githubToken: config.githubToken } : {}),
+    ...(dashboardDir ? { dashboardDir } : {}),
   })
 
   const server = serve({ fetch: app.fetch, port: config.port }, (info) => {
@@ -115,6 +120,29 @@ async function main(): Promise<void> {
   }
   process.on('SIGINT', () => shutdown('SIGINT'))
   process.on('SIGTERM', () => shutdown('SIGTERM'))
+}
+
+/**
+ * Phase 5 / Sub 5.1: locate the dashboard's static build. Resolution order:
+ *   1. MAESTRO_DASHBOARD_DIR (explicit override)
+ *   2. /app/dashboard (the Docker image layout)
+ *   3. ../../dashboard/dist relative to this file (repo layout —
+ *      packages/conductor/{src,dist} → packages/dashboard/dist)
+ * Returns undefined when none exist; in dev that's normal (Vite serves
+ * the dashboard itself on 5173).
+ */
+function resolveDashboardDir(): string | undefined {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    process.env['MAESTRO_DASHBOARD_DIR'],
+    '/app/dashboard',
+    resolve(here, '../../dashboard/dist'),
+  ].filter((c): c is string => Boolean(c))
+  for (const candidate of candidates) {
+    if (existsSync(resolve(candidate, 'index.html'))) return resolve(candidate)
+  }
+  logger.debug({ candidates }, 'no static dashboard build found — /api only')
+  return undefined
 }
 
 main().catch((err) => {

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -11,8 +11,9 @@ import { logger as honoLogger } from 'hono/logger'
 import { HTTPException } from 'hono/http-exception'
 import { ZodError } from 'zod'
 import { existsSync } from 'node:fs'
-import { stat } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { createReadStream } from 'node:fs'
+import { extname, join, normalize, resolve as resolvePath } from 'node:path'
 import {
   CostAggregationsResponseSchema,
   GetProjectFeedbackResponseSchema,
@@ -100,6 +101,13 @@ export interface ServerDeps {
    */
   githubToken?: string
   githubClient?: GitHubClient
+  /**
+   * Phase 5 / Sub 5.1: absolute path to the dashboard's static build
+   * (vite dist). When set and the directory exists, every non-/api GET
+   * serves from it with an index.html SPA fallback. Unset in tests that
+   * don't care and in dev (Vite serves the dashboard itself).
+   */
+  dashboardDir?: string
 }
 
 export function buildServer(deps: ServerDeps): Hono {
@@ -635,11 +643,92 @@ export function buildServer(deps: ServerDeps): Hono {
     return c.json(body)
   })
 
+  // ── Phase 5 / Sub 5.1: static dashboard ─────────────────────────────
+  // Registered last so every /api route wins first. Any other GET serves
+  // the vite build with an index.html SPA fallback. Unmatched /api GETs
+  // still return JSON 404 (the guard below), never HTML.
+  if (deps.dashboardDir && existsSync(deps.dashboardDir)) {
+    const root = resolvePath(deps.dashboardDir)
+    app.get('*', async (c) => {
+      const path = c.req.path
+      if (path.startsWith('/api')) {
+        return c.json({ error: { code: 'NOT_FOUND', message: `No route for ${path}` } }, 404)
+      }
+      const served = await serveDashboardFile(root, path)
+      if (!served) {
+        return c.json({ error: { code: 'NOT_FOUND', message: `No route for ${path}` } }, 404)
+      }
+      return c.body(new Uint8Array(served.body), 200, {
+        'content-type': served.contentType,
+        'cache-control': served.immutable
+          ? 'public, max-age=31536000, immutable'
+          : 'no-cache',
+      })
+    })
+    logger.info({ dashboardDir: root }, 'serving static dashboard')
+  }
+
   app.notFound((c) =>
     c.json({ error: { code: 'NOT_FOUND', message: `No route for ${c.req.path}` } }, 404),
   )
 
   return app
+}
+
+// ─── Static dashboard helpers (Phase 5 / Sub 5.1) ────────────────────
+
+const STATIC_CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+}
+
+interface ServedFile {
+  body: Buffer
+  contentType: string
+  /** Vite emits content-hashed filenames under /assets — cache forever. */
+  immutable: boolean
+}
+
+async function serveDashboardFile(root: string, urlPath: string): Promise<ServedFile | null> {
+  // Normalize + contain within root. Anything that escapes (.. traversal,
+  // encoded slashes) collapses to the SPA fallback or 404 — never a read
+  // outside `root`.
+  const decoded = decodeURIComponent(urlPath)
+  const relative = normalize(decoded).replace(/^([/\\])+/, '')
+  const candidate = resolvePath(join(root, relative))
+  if (!candidate.startsWith(root)) return null
+
+  const tryRead = async (filePath: string): Promise<ServedFile | null> => {
+    try {
+      const info = await stat(filePath)
+      if (!info.isFile()) return null
+      const body = await readFile(filePath)
+      const ext = extname(filePath).toLowerCase()
+      return {
+        body,
+        contentType: STATIC_CONTENT_TYPES[ext] ?? 'application/octet-stream',
+        immutable: filePath.includes(`${join(root, 'assets')}`) && ext !== '.html',
+      }
+    } catch {
+      return null
+    }
+  }
+
+  // Exact file (e.g. /assets/index-abc.js), else SPA fallback for
+  // route-ish paths (no extension), else nothing.
+  const exact = await tryRead(candidate === root ? join(root, 'index.html') : candidate)
+  if (exact) return exact
+  if (extname(decoded) === '') return tryRead(join(root, 'index.html'))
+  return null
 }
 
 function notFoundProject(c: Context, slug: string): Response {

--- a/packages/conductor/src/test/server-static.test.ts
+++ b/packages/conductor/src/test/server-static.test.ts
@@ -1,0 +1,108 @@
+// Phase 5 / Sub 5.1 — static dashboard serving.
+//
+// Asserts: exact assets serve with the right content-type + cache headers,
+// SPA routes fall back to index.html, /api keeps JSON 404 semantics, and
+// path traversal cannot escape the dashboard root.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { openDatabase, type DbHandle } from '../db.js'
+import { buildServer } from '../server.js'
+
+interface Harness {
+  db: DbHandle
+  root: string
+  dashboardDir: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-static-'))
+  const db = openDatabase({ dataDir: root })
+  const dashboardDir = join(root, 'dashboard')
+  await mkdir(join(dashboardDir, 'assets'), { recursive: true })
+  await writeFile(join(dashboardDir, 'index.html'), '<!doctype html><div id="app">maestro</div>')
+  await writeFile(join(dashboardDir, 'assets', 'index-abc123.js'), 'console.log("app")')
+  await writeFile(join(root, 'secret.txt'), 'do-not-serve')
+  h = { db, root, dashboardDir }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+function server() {
+  if (!h) throw new Error('harness missing')
+  return buildServer({
+    startedAt: Date.now(),
+    version: 'test',
+    db: h.db.db,
+    dataDir: h.root,
+    developerName: 'Tester',
+    dashboardDir: h.dashboardDir,
+  })
+}
+
+describe('static dashboard serving', () => {
+  it('serves index.html at /', async () => {
+    const res = await server().request('/')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(await res.text()).toContain('maestro')
+  })
+
+  it('serves hashed assets with immutable caching', async () => {
+    const res = await server().request('/assets/index-abc123.js')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('javascript')
+    expect(res.headers.get('cache-control')).toContain('immutable')
+    expect(await res.text()).toContain('console.log')
+  })
+
+  it('falls back to index.html for SPA routes', async () => {
+    const res = await server().request('/projects/some-slug/feedback')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(res.headers.get('cache-control')).toBe('no-cache')
+  })
+
+  it('keeps JSON 404 semantics for unmatched /api paths', async () => {
+    const res = await server().request('/api/definitely-not-a-route')
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toContain('application/json')
+  })
+
+  it('still serves real API routes first', async () => {
+    const res = await server().request('/api/health')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { status: string }
+    expect(body.status).toBe('ok')
+  })
+
+  it('does not serve files outside the dashboard root', async () => {
+    // ../secret.txt sits next to the dashboard dir; traversal must not
+    // reach it. Either 404 or SPA fallback is fine — never the secret.
+    const res = await server().request('/..%2Fsecret.txt')
+    const text = await res.text()
+    expect(text).not.toContain('do-not-serve')
+  })
+
+  it('omitting dashboardDir keeps the API-only behavior', async () => {
+    if (!h) throw new Error('harness missing')
+    const app = buildServer({
+      startedAt: Date.now(),
+      version: 'test',
+      db: h.db.db,
+      dataDir: h.root,
+      developerName: 'Tester',
+    })
+    const res = await app.request('/')
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
Closes #62. Part of Phase 5 (plan: 5.1).

- Non-/api GETs serve the vite build, SPA fallback to index.html; /api keeps JSON 404s
- dashboardDir resolution: MAESTRO_DASHBOARD_DIR → /app/dashboard → packages/dashboard/dist
- Custom absolute-root reader instead of serveStatic (cwd-relative root = the #34 bug class); traversal containment unit-tested
- 7 new tests; DEPLOYMENT.md note updated

Test plan: suite green (122 tests), lint clean, Docker parity verified in 5.5 PR.