### PR TITLE
[#66] feat(conductor): Claude CLI health surface + Railway volume bootstrap

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -440,4 +440,20 @@ The chain stops when:
 
 ---
 
+## ADR-025: Claude Code baked into the image, OAuth persisted on the volume
+
+**Date**: 2026-05-18
+**Decision**: The runtime Docker image installs `@anthropic-ai/claude-code` globally and sets `CLAUDE_CONFIG_DIR=/data/claude`, so OAuth credentials live on the persistent volume and survive redeploys. Bootstrap is a one-time interactive step on the deploy host (`railway shell` → `claude /login`). A new `GET /api/health/claude` endpoint reports `{installed, version, authenticated, credentialsAt, configDir}`, and the dashboard shows a warning banner when the CLI is missing or unauthenticated.
+
+**Reasoning**: ADR-001 committed to the subscription-backed CLI rather than API keys. The open question was where the CLI lives for a hosted deploy. Baking it into the image with volume-persisted config keeps ADR-001 intact: same auth model, same invocation pattern (ADR-011), zero code changes in the worker. The alternative — `ANTHROPIC_API_KEY` — would change billing (pay-per-token), require a claude-runner refactor, and contradict ADR-001 for no operational gain.
+
+**Known risks**:
+- OAuth token rotation/expiry requires re-running the bootstrap. The health endpoint + dashboard banner make this visible before sessions start failing silently.
+- `authenticated` detection reads the credentials file under `CLAUDE_CONFIG_DIR`; on macOS the token lives in the Keychain, so the endpoint reports `null` ("unknown") there rather than a false negative.
+- If Railway's interactive shell access regresses, the fallback is a plain VPS (documented in DEPLOYMENT.md) — the image works identically anywhere Docker runs.
+
+**Subscription note**: heavy multi-project automation can hit Pro/Max weekly caps. The existing throttles (`maxSessionsPerDay`, cost-throttle skip rule, opt-in `continueUntilBudget`) are the mitigations; the health endpoint is the observability hook.
+
+---
+
 *Add new decisions above this line. Keep them numbered sequentially.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@
 # conductor needs at runtime. The image runs the conductor + serves the static
 # dashboard from the Hono app's working tree.
 #
-# git is installed because future phases run `simple-git` against managed
-# project repos. The Claude Code CLI is intentionally NOT baked into this
-# image — it must be installed and OAuth'd interactively on the host, per
-# ADR-001.
+# git is installed because the conductor runs `simple-git` against managed
+# project repos. The Claude Code CLI IS baked into the runtime image
+# (ADR-025): OAuth credentials persist on the /data volume via
+# CLAUDE_CONFIG_DIR, so a one-time `railway shell` → `claude /login`
+# bootstrap survives redeploys. ADR-001 (subscription via CLI, not API)
+# still holds — only the install location moved.
 
 # ─── builder ─────────────────────────────────────────────────────────
 FROM node:22-bookworm-slim AS builder
@@ -48,13 +50,18 @@ FROM node:22-bookworm-slim AS runtime
 
 ENV NODE_ENV=production \
     MAESTRO_PORT=3000 \
-    MAESTRO_DATA_DIR=/data
+    MAESTRO_DATA_DIR=/data \
+    CLAUDE_CONFIG_DIR=/data/claude
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates git tini \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --system --gid 1001 maestro \
   && useradd  --system --uid 1001 --gid maestro --create-home maestro
+
+# Claude Code CLI (ADR-025). Version-pinned implicitly by image build
+# date; `claude --version` is surfaced at /api/health/claude.
+RUN npm install -g @anthropic-ai/claude-code
 
 WORKDIR /app
 
@@ -71,4 +78,5 @@ EXPOSE 3000
 VOLUME ["/data"]
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["node", "/app/conductor/dist/index.js"]
+# mkdir at start, not build: the /data volume mount shadows image-time dirs.
+CMD ["/bin/sh", "-c", "mkdir -p \"$CLAUDE_CONFIG_DIR\" && exec node /app/conductor/dist/index.js"]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,6 +62,34 @@ conductor looks for `MAESTRO_DASHBOARD_DIR`, then the repo-relative
 `packages/dashboard/dist`. Opening `https://maestro.<your-domain>/`
 should render the Overview page with no separate dashboard process.
 
+## Claude Code bootstrap (one-time per deploy host)
+
+The image ships the Claude Code CLI with `CLAUDE_CONFIG_DIR=/data/claude`,
+so OAuth credentials persist on the volume across redeploys (ADR-025).
+After the **first** deploy (and again only if the token ever expires):
+
+```bash
+railway shell           # opens a shell inside the running service
+claude /login           # follow the OAuth URL, paste the code back
+claude --version        # sanity check
+exit
+```
+
+Verify from outside:
+
+```bash
+curl https://maestro.<your-domain>/api/health/claude
+# → { "installed": true, "version": "…", "authenticated": true, … }
+```
+
+The dashboard shows a yellow banner whenever this endpoint reports the
+CLI missing or unauthenticated — if you see it, re-run the bootstrap.
+
+**Fallback — plain VPS.** If interactive shell access on Railway breaks,
+the same image runs anywhere Docker does (DigitalOcean, Hetzner, a home
+server): `docker run -v maestro-data:/data -p 3000:3000 <image>`, then
+`docker exec -it <container> claude /login`.
+
 ## Updating
 
 ```bash

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -180,6 +180,45 @@ export function buildServer(deps: ServerDeps): Hono {
     )
   })
 
+  // Phase 5 / Sub 5.5: Claude CLI health. Surfaces "is the agent runtime
+  // actually usable on this host" — the gating question for any deploy.
+  // `authenticated` is best-effort: a credentials file under
+  // CLAUDE_CONFIG_DIR (Linux/Docker) is checkable; the macOS keychain is
+  // not, so we report null ("unknown") rather than guessing.
+  app.get('/api/health/claude', async (c) => {
+    const { execa } = await import('execa')
+    const claudeBin = process.env['MAESTRO_CLAUDE_BIN'] ?? 'claude'
+    const probe = await execa(claudeBin, ['--version'], {
+      reject: false,
+      timeout: 3000,
+    })
+    const installed = probe.exitCode === 0
+    const version = installed ? (probe.stdout ?? '').trim() || null : null
+
+    const configDir =
+      process.env['CLAUDE_CONFIG_DIR'] ??
+      join(process.env['HOME'] ?? '/root', '.claude')
+    let credentialsAt: string | null = null
+    let authenticated: boolean | null = null
+    try {
+      const info = await stat(join(configDir, '.credentials.json'))
+      credentialsAt = info.mtime.toISOString()
+      authenticated = true
+    } catch {
+      // No file ⇒ on Linux/Docker that means not logged in; on macOS the
+      // keychain holds the OAuth token, so absence proves nothing.
+      authenticated = process.platform === 'darwin' ? null : installed ? false : null
+    }
+
+    return c.json({
+      installed,
+      version,
+      authenticated,
+      credentialsAt,
+      configDir,
+    })
+  })
+
   app.get('/api/health', (c) => {
     const body = HealthResponseSchema.parse({
       status: 'ok',

--- a/packages/conductor/src/test/claude-health.test.ts
+++ b/packages/conductor/src/test/claude-health.test.ts
@@ -1,0 +1,83 @@
+// Phase 5 / Sub 5.5 — GET /api/health/claude.
+//
+// The probe is made deterministic by pointing MAESTRO_CLAUDE_BIN at
+// binaries with known behavior: /bin/echo exits 0 for any args
+// (installed=true), a nonexistent path fails (installed=false).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { openDatabase, type DbHandle } from '../db.js'
+import { buildServer } from '../server.js'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+let savedBin: string | undefined
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-claude-health-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+  savedBin = process.env['MAESTRO_CLAUDE_BIN']
+})
+
+afterEach(async () => {
+  if (savedBin === undefined) delete process.env['MAESTRO_CLAUDE_BIN']
+  else process.env['MAESTRO_CLAUDE_BIN'] = savedBin
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+function server() {
+  if (!h) throw new Error('harness missing')
+  return buildServer({
+    startedAt: Date.now(),
+    version: 'test',
+    db: h.db.db,
+    dataDir: h.root,
+    developerName: 'Tester',
+  })
+}
+
+interface ClaudeHealthBody {
+  installed: boolean
+  version: string | null
+  authenticated: boolean | null
+  credentialsAt: string | null
+  configDir: string
+}
+
+describe('GET /api/health/claude', () => {
+  it('reports installed=true with a version when the probe binary exits 0', async () => {
+    process.env['MAESTRO_CLAUDE_BIN'] = '/bin/echo'
+    const res = await server().request('/api/health/claude')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ClaudeHealthBody
+    expect(body.installed).toBe(true)
+    expect(body.version).toBeTruthy() // echo prints "--version"
+    expect(typeof body.configDir).toBe('string')
+  })
+
+  it('reports installed=false when the binary does not exist', async () => {
+    process.env['MAESTRO_CLAUDE_BIN'] = '/definitely/not/a/real/binary'
+    const res = await server().request('/api/health/claude')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as ClaudeHealthBody
+    expect(body.installed).toBe(false)
+    expect(body.version).toBeNull()
+  })
+
+  it('authenticated is boolean or null, never undefined', async () => {
+    process.env['MAESTRO_CLAUDE_BIN'] = '/bin/echo'
+    const res = await server().request('/api/health/claude')
+    const body = (await res.json()) as ClaudeHealthBody
+    expect([true, false, null]).toContain(body.authenticated)
+  })
+})

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,8 +1,16 @@
 import { NavLink, Outlet } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useStore } from '../store/useStore'
 import { useApi } from '../hooks/useApi'
 import type { HealthResponse } from '@maestro/api'
+
+interface ClaudeHealth {
+  installed: boolean
+  version: string | null
+  authenticated: boolean | null
+  credentialsAt: string | null
+  configDir: string
+}
 
 interface NavItem {
   to: string
@@ -23,6 +31,7 @@ const NAV: NavItem[] = [
 export function Layout() {
   const { setHealth, health } = useStore()
   const api = useApi()
+  const [claude, setClaude] = useState<ClaudeHealth | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -36,11 +45,27 @@ export function Layout() {
     }
     void tick()
     const id = window.setInterval(tick, 15_000)
+    // Claude health is slow-moving — probe once per mount.
+    void api
+      .get<ClaudeHealth>('/api/health/claude')
+      .then((res) => {
+        if (!cancelled) setClaude(res)
+      })
+      .catch(() => {
+        /* endpoint unavailable — banner stays hidden */
+      })
     return () => {
       cancelled = true
       window.clearInterval(id)
     }
   }, [api, setHealth])
+
+  const claudeWarning =
+    claude && (!claude.installed || claude.authenticated === false)
+      ? !claude.installed
+        ? 'Claude Code CLI is not installed on the conductor host — sessions cannot run. See docs/DEPLOYMENT.md.'
+        : `Claude Code is installed but not authenticated (no credentials under ${claude.configDir}). Run \`claude /login\` on the conductor host.`
+      : null
 
   return (
     <div className="flex h-full bg-navy-900 text-navy-100">
@@ -76,6 +101,11 @@ export function Layout() {
           </div>
           <StatusIndicator health={health} />
         </header>
+        {claudeWarning ? (
+          <div className="border-b border-warning/40 bg-warning/10 px-6 py-2 text-sm text-warning">
+            {claudeWarning}
+          </div>
+        ) : null}
         <main className="flex-1 overflow-y-auto px-6 py-8">
           <Outlet />
         </main>

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "node /app/conductor/dist/index.js",
+    "startCommand": "/bin/sh -c 'mkdir -p \"$CLAUDE_CONFIG_DIR\" && exec node /app/conductor/dist/index.js'",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/api/health",


### PR DESCRIPTION
Closes #66. Part of Phase 5 (plan: 5.5).

- GET /api/health/claude: install probe + credentials-file check (tri-state authenticated; macOS keychain → null)
- Dashboard banner when CLI missing/unauthenticated
- Dockerfile bakes @anthropic-ai/claude-code, CLAUDE_CONFIG_DIR=/data/claude (volume-persisted OAuth); railway.json startCommand mkdirs it
- DEPLOYMENT.md bootstrap recipe (railway shell → claude /login) + VPS fallback; ADR-025

Test plan: 3 new deterministic tests; suite green; lint clean. Live Railway bootstrap verified at first deploy.