### PR TITLE
[#63] feat(conductor): HTTP Basic Auth + same-origin-by-default CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,14 @@ DEVELOPER_GITHUB_USERNAME=aaryansinha16
 # Where the dashboard expects the conductor API. In dev this is proxied
 # through Vite, so usually unset locally.
 # VITE_API_BASE_URL=http://localhost:3000
+
+# ─── Auth (Phase 5) ──────────────────────────────────────────────────
+# When BOTH are set, the dashboard + API require HTTP Basic Auth
+# (except /api/health, kept open for platform healthchecks). REQUIRED
+# for any public deployment. Password must be ≥ 8 chars.
+# MAESTRO_AUTH_USER=
+# MAESTRO_AUTH_PASSWORD=
+
+# Optional CORS allow-origin. Leave unset (same-origin only) unless a
+# separately-hosted frontend needs API access.
+# MAESTRO_CORS_ORIGIN=

--- a/packages/conductor/src/config.ts
+++ b/packages/conductor/src/config.ts
@@ -46,6 +46,15 @@ const ConfigSchema = z.object({
   telegramBotToken: z.string().optional(),
   telegramChatId: z.string().optional(),
   anthropicApiKey: z.string().optional(),
+  // Phase 5 / Sub 5.2: when BOTH are set, the whole app (static + API,
+  // minus /api/health) sits behind HTTP Basic Auth. Either missing →
+  // auth disabled with a startup warning. Single-user v1; magic-link
+  // deferred to Phase 6.
+  authUser: z.string().min(1).optional(),
+  authPassword: z.string().min(8).optional(),
+  // Optional CORS allowlist origin. Unset → no CORS middleware at all
+  // (same-origin only — correct once the conductor serves the dashboard).
+  corsOrigin: z.string().optional(),
   nodeEnv: z.enum(['development', 'production', 'test']).default('development'),
 })
 
@@ -62,6 +71,9 @@ export function loadConfig(): Config {
     telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || undefined,
     telegramChatId: process.env.TELEGRAM_CHAT_ID || undefined,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || undefined,
+    authUser: process.env.MAESTRO_AUTH_USER || undefined,
+    authPassword: process.env.MAESTRO_AUTH_PASSWORD || undefined,
+    corsOrigin: process.env.MAESTRO_CORS_ORIGIN || undefined,
     nodeEnv: process.env.NODE_ENV,
   })
 

--- a/packages/conductor/src/index.ts
+++ b/packages/conductor/src/index.ts
@@ -98,6 +98,9 @@ async function main(): Promise<void> {
     schedulerTimezone: process.env['MAESTRO_TZ'] ?? 'UTC',
     ...(config.githubToken ? { githubToken: config.githubToken } : {}),
     ...(dashboardDir ? { dashboardDir } : {}),
+    ...(config.authUser ? { authUser: config.authUser } : {}),
+    ...(config.authPassword ? { authPassword: config.authPassword } : {}),
+    ...(config.corsOrigin ? { corsOrigin: config.corsOrigin } : {}),
   })
 
   const server = serve({ fetch: app.fetch, port: config.port }, (info) => {

--- a/packages/conductor/src/server.ts
+++ b/packages/conductor/src/server.ts
@@ -6,6 +6,7 @@
 // happened" view.
 
 import { Hono, type Context } from 'hono'
+import { basicAuth } from 'hono/basic-auth'
 import { cors } from 'hono/cors'
 import { logger as honoLogger } from 'hono/logger'
 import { HTTPException } from 'hono/http-exception'
@@ -108,6 +109,17 @@ export interface ServerDeps {
    * don't care and in dev (Vite serves the dashboard itself).
    */
   dashboardDir?: string
+  /**
+   * Phase 5 / Sub 5.2: HTTP Basic Auth. When BOTH are set, everything
+   * except /api/health (the Railway healthcheck path) requires
+   * credentials. Top-level navigation triggers the browser's native
+   * dialog; same-origin fetches then carry the header automatically, so
+   * no login page is needed for single-user v1.
+   */
+  authUser?: string
+  authPassword?: string
+  /** Optional CORS allow origin. Unset → no CORS middleware (same-origin only). */
+  corsOrigin?: string
 }
 
 export function buildServer(deps: ServerDeps): Hono {
@@ -147,7 +159,30 @@ export function buildServer(deps: ServerDeps): Hono {
   const PROBE_CACHE_TTL_MS = 60_000
 
   app.use('*', honoLogger((msg) => logger.debug(msg)))
-  app.use('/api/*', cors({ origin: '*' }))
+  // CORS only when an explicit origin allowlist is configured. The
+  // production layout serves the dashboard same-origin (Sub 5.1) and the
+  // dev layout proxies through Vite — neither needs CORS.
+  if (deps.corsOrigin) {
+    app.use('/api/*', cors({ origin: deps.corsOrigin }))
+  }
+
+  // Phase 5 / Sub 5.2: Basic Auth across static + API. /api/health stays
+  // open for platform healthchecks (Railway probes it unauthenticated).
+  if (deps.authUser && deps.authPassword) {
+    const requireAuth = basicAuth({
+      username: deps.authUser,
+      password: deps.authPassword,
+    })
+    app.use('*', async (c, next) => {
+      if (c.req.path === '/api/health') return next()
+      return requireAuth(c, next)
+    })
+    logger.info({ user: deps.authUser }, 'basic auth enabled')
+  } else if (deps.authUser || deps.authPassword) {
+    logger.warn(
+      'MAESTRO_AUTH_USER / MAESTRO_AUTH_PASSWORD: only one is set — auth DISABLED. Set both.',
+    )
+  }
 
   app.onError((err, c) => {
     if (err instanceof HTTPException) return err.getResponse()

--- a/packages/conductor/src/test/server-auth.test.ts
+++ b/packages/conductor/src/test/server-auth.test.ts
@@ -1,0 +1,81 @@
+// Phase 5 / Sub 5.2 — HTTP Basic Auth.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { openDatabase, type DbHandle } from '../db.js'
+import { buildServer, type ServerDeps } from '../server.js'
+
+interface Harness {
+  db: DbHandle
+  root: string
+}
+let h: Harness | null = null
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maestro-auth-'))
+  const db = openDatabase({ dataDir: root })
+  h = { db, root }
+})
+
+afterEach(async () => {
+  if (h) {
+    h.db.close()
+    await rm(h.root, { recursive: true, force: true })
+    h = null
+  }
+})
+
+function server(extra: Partial<ServerDeps> = {}) {
+  if (!h) throw new Error('harness missing')
+  return buildServer({
+    startedAt: Date.now(),
+    version: 'test',
+    db: h.db.db,
+    dataDir: h.root,
+    developerName: 'Tester',
+    ...extra,
+  })
+}
+
+const CREDS = { authUser: 'dev', authPassword: 'hunter22hunter22' }
+const basic = (user: string, pass: string) =>
+  `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`
+
+describe('basic auth', () => {
+  it('401s API requests without credentials when auth is configured', async () => {
+    const res = await server(CREDS).request('/api/projects')
+    expect(res.status).toBe(401)
+    expect(res.headers.get('www-authenticate')).toContain('Basic')
+  })
+
+  it('200s with correct credentials', async () => {
+    const res = await server(CREDS).request('/api/projects', {
+      headers: { authorization: basic('dev', 'hunter22hunter22') },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('401s with wrong credentials', async () => {
+    const res = await server(CREDS).request('/api/projects', {
+      headers: { authorization: basic('dev', 'wrong-password') },
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('keeps /api/health open for platform healthchecks', async () => {
+    const res = await server(CREDS).request('/api/health')
+    expect(res.status).toBe(200)
+  })
+
+  it('auth disabled when credentials are not configured', async () => {
+    const res = await server().request('/api/projects')
+    expect(res.status).toBe(200)
+  })
+
+  it('auth disabled (with warning) when only one of the pair is set', async () => {
+    const res = await server({ authUser: 'dev' }).request('/api/projects')
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
Closes #63. Part of Phase 5 (plan: 5.2).

- Both env vars set → Basic Auth on static + /api/*, except /api/health (Railway healthcheck)
- Half-configured → warning + disabled (never silently half-locked)
- Browser-native credential dialog; no login page needed for single-user v1; magic-link → Phase 6
- CORS now opt-in via MAESTRO_CORS_ORIGIN (was origin:'*')

Test plan: 6 new tests; suite green; lint clean.