### PR TITLE
fix(docker): drop VOLUME instruction — Railway rejects it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,12 @@ RUN mkdir -p /data && chown maestro:maestro /data
 USER maestro
 
 EXPOSE 3000
-VOLUME ["/data"]
+
+# NB: no Docker `VOLUME` instruction — Railway rejects it ("use Railway
+# Volumes"). Persistence at /data is configured via a Railway Volume
+# mounted at that path (see docs/DEPLOYMENT.md), which is what actually
+# survives redeploys. The VOLUME hint would only matter for a plain
+# `docker run` without -v, and there we pass -v explicitly anyway.
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 # mkdir at start, not build: the /data volume mount shadows image-time dirs.


### PR DESCRIPTION
## Problem
Railway's Metal builder fails the build:
```
dockerfile invalid: docker VOLUME at Line 78 is not supported, use Railway Volumes
```

## Fix
Remove the \`VOLUME ["/data"]\` instruction. Railway handles persistence via its own Volumes feature (a volume mounted at \`/data\` in service settings) — the Docker \`VOLUME\` hint was only a marker. Actual persistence comes from the \`-v\` mount (local \`docker run\`) or the Railway Volume (hosted), both already documented in docs/DEPLOYMENT.md. No behavioural change.

## Test plan
- [x] Dockerfile still builds locally (only an instruction removed)
- [ ] Railway build succeeds after merge