### PR TITLE
fix(docker): chown volume + drop to non-root via gosu entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,10 @@ ENV NODE_ENV=production \
     MAESTRO_DATA_DIR=/data \
     CLAUDE_CONFIG_DIR=/data/claude
 
+# gosu lets the entrypoint drop from root → maestro after fixing volume
+# ownership at runtime (see docker-entrypoint.sh).
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates git tini \
+  && apt-get install -y --no-install-recommends ca-certificates git tini gosu \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --system --gid 1001 maestro \
   && useradd  --system --uid 1001 --gid maestro --create-home maestro
@@ -71,17 +73,19 @@ COPY --from=builder --chown=maestro:maestro /prod/conductor /app/conductor
 # Dashboard static build, served from inside the conductor process tree.
 COPY --from=builder --chown=maestro:maestro /app/packages/dashboard/dist /app/dashboard
 
-RUN mkdir -p /data && chown maestro:maestro /data
-USER maestro
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && mkdir -p /data
 
 EXPOSE 3000
 
 # NB: no Docker `VOLUME` instruction — Railway rejects it ("use Railway
-# Volumes"). Persistence at /data is configured via a Railway Volume
-# mounted at that path (see docs/DEPLOYMENT.md), which is what actually
-# survives redeploys. The VOLUME hint would only matter for a plain
-# `docker run` without -v, and there we pass -v explicitly anyway.
-
-ENTRYPOINT ["/usr/bin/tini", "--"]
-# mkdir at start, not build: the /data volume mount shadows image-time dirs.
-CMD ["/bin/sh", "-c", "mkdir -p \"$CLAUDE_CONFIG_DIR\" && exec node /app/conductor/dist/index.js"]
+# Volumes"). Persistence at /data comes from a Railway Volume mounted
+# there (docs/DEPLOYMENT.md), or `docker run -v` locally.
+#
+# We deliberately do NOT set `USER maestro`: the entrypoint starts as
+# root to chown the runtime-mounted /data volume, then drops to maestro
+# via gosu before exec'ing node. Net effect — the conductor process runs
+# unprivileged (CLAUDE.md security boundary) while still being able to
+# write the volume Railway hands us root-owned.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
+CMD ["node", "/app/conductor/dist/index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Container entrypoint (Phase 5 deployment).
+#
+# Railway (and `docker run -v`) mount the persistent volume at /data
+# owned by root, which shadows the image-time `chown maestro:maestro /data`.
+# The conductor runs as the non-root `maestro` user, so it can't write
+# there until ownership is fixed at runtime.
+#
+# This script starts as root, makes /data writable by maestro, then drops
+# privileges via gosu before exec'ing the conductor. That keeps the
+# non-root security boundary from CLAUDE.md without needing the blunt
+# RAILWAY_RUN_UID=0 (run-everything-as-root) workaround.
+set -e
+
+DATA_DIR="${MAESTRO_DATA_DIR:-/data}"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$DATA_DIR/claude}"
+
+mkdir -p "$DATA_DIR" "$CLAUDE_DIR"
+# Only chown when needed — a -R sweep over a large /data on every boot is
+# wasteful, so gate on the top-level owner.
+if [ "$(stat -c '%U' "$DATA_DIR")" != "maestro" ]; then
+  chown -R maestro:maestro "$DATA_DIR"
+fi
+
+exec gosu maestro "$@"

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,6 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "/bin/sh -c 'mkdir -p \"$CLAUDE_CONFIG_DIR\" && exec node /app/conductor/dist/index.js'",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/api/health",


### PR DESCRIPTION
## Problem
Railway mounts the persistent volume at \`/data\` **root-owned**, shadowing the image-time \`chown maestro:maestro /data\`. With \`USER maestro\`, the conductor can't write \`/data/claude\` or \`maestro.db\` → EACCES crash-loop on first deploy with a volume attached.

## Fix
A runtime entrypoint instead of the blunt \`RAILWAY_RUN_UID=0\` (run-everything-as-root) workaround — keeps the non-root security boundary from CLAUDE.md:
- \`docker-entrypoint.sh\`: start as root → \`mkdir\`+\`chown\` \`/data\` to maestro (gated on current owner) → \`exec gosu maestro "$@"\`.
- Dockerfile: install \`gosu\`, drop \`USER maestro\`, \`ENTRYPOINT = tini -- docker-entrypoint.sh\`, \`CMD = node …/index.js\`.
- railway.json: remove the \`startCommand\` override (it bypassed the entrypoint).

## Verified locally
Built the image and ran it with a root-owned host volume at \`/data\`:
- node process runs as uid 1001 (gosu drop confirmed via /proc)
- \`/data\` + \`/data/claude\` become maestro-owned
- \`/api/health\` → ok
- \`/api/health/claude\` → installed=true, authenticated=false (pending \`claude /login\`)