### PR TITLE
fix(deploy): honor platform $PORT so Railway healthcheck can reach the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,11 @@ RUN pnpm --filter @maestro/conductor deploy --legacy --prod /prod/conductor
 # ─── runtime ─────────────────────────────────────────────────────────
 FROM node:22-bookworm-slim AS runtime
 
+# NB: no MAESTRO_PORT here. Hardcoding it would shadow the platform's
+# $PORT (Railway assigns one and routes the healthcheck + public traffic
+# to it). config.ts reads MAESTRO_PORT ?? PORT ?? default, so leaving it
+# unset lets $PORT win on the host and falls back to 3000 otherwise.
 ENV NODE_ENV=production \
-    MAESTRO_PORT=3000 \
     MAESTRO_DATA_DIR=/data \
     CLAUDE_CONFIG_DIR=/data/claude
 

--- a/packages/conductor/src/config.ts
+++ b/packages/conductor/src/config.ts
@@ -67,7 +67,11 @@ export type Config = z.infer<typeof ConfigSchema>
 
 export function loadConfig(): Config {
   const parsed = ConfigSchema.safeParse({
-    port: process.env.MAESTRO_PORT,
+    // MAESTRO_PORT is the explicit local override; PORT is the platform
+    // convention (Railway/Heroku/etc. assign it and route the healthcheck
+    // + public traffic to it). Preferring MAESTRO_PORT keeps local dev
+    // stable while letting a hosted platform pick the port it routes to.
+    port: process.env.MAESTRO_PORT ?? process.env.PORT,
     dataDir: process.env.MAESTRO_DATA_DIR,
     developerName: process.env.DEVELOPER_NAME,
     developerEmail: process.env.DEVELOPER_EMAIL || undefined,

--- a/railway.json
+++ b/railway.json
@@ -8,6 +8,6 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5,
     "healthcheckPath": "/api/health",
-    "healthcheckTimeout": 30
+    "healthcheckTimeout": 300
   }
 }


### PR DESCRIPTION
## Problem
First Railway deploy built and **fully booted** (runtime logs: \`database opened\` → \`serving static dashboard\` → \`conductor listening\`), but the healthcheck failed — \`service unavailable\` for 30s, then Railway killed the container. Root cause: the conductor hardcoded \`MAESTRO_PORT=3000\` (Dockerfile ENV) while Railway routes the healthcheck + traffic to the port it assigns via \`$PORT\`, which the app ignored → wrong-port connection refused.

## Fix
- `config.ts`: `port` now reads `MAESTRO_PORT ?? PORT ?? default`. Local dev keeps `MAESTRO_PORT` (.env); a platform's `$PORT` wins when `MAESTRO_PORT` is unset.
- `Dockerfile`: drop the hardcoded `MAESTRO_PORT=3000` ENV so it doesn't shadow `$PORT`. `EXPOSE 3000` stays.
- `railway.json`: `healthcheckTimeout` 30 → 300.
- Paired with a Railway service var `PORT=3000`.

`@hono/node-server` already binds dual-stack `::`, so IPv6/IPv4 reachability was never the issue.

## Test plan
- [x] `pnpm -r test` (141/141), lint clean
- [ ] Railway deploy passes healthcheck (verifying post-merge)