### PR TITLE
fix(deploy): system git credential helper so the worker can push on Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,16 @@ RUN apt-get update \
 # date; `claude --version` is surfaced at /api/health/claude.
 RUN npm install -g @anthropic-ai/claude-code
 
+# System-wide git credential helper so the worker can push over HTTPS on a
+# headless host. It feeds GITHUB_TOKEN from the environment at push time —
+# the token is never written to disk, baked into the image, or placed in a
+# remote URL. Only processes whose env carries GITHUB_TOKEN (the conductor)
+# get a usable credential; a process without it (a sandboxed agent) gets an
+# empty password and cannot push. Responds only to `get` so store/erase are
+# no-ops.
+RUN git config --system credential.helper \
+  '!f() { test "$1" = get && echo username=x-access-token && echo "password=$GITHUB_TOKEN"; }; f'
+
 WORKDIR /app
 
 # Conductor runtime artefact (production deps + compiled JS + migrations).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -27,26 +27,16 @@ volume, one set of environment variables.
    - `DEVELOPER_NAME=Aaryan Sinha`
    - `DEVELOPER_EMAIL=<your GitHub email>`
    - `DEVELOPER_GITHUB_USERNAME=aaryansinha16`
-   - `MAESTRO_DATA_DIR=/data`
-   - `MAESTRO_PORT=3000`
+   - `MAESTRO_AUTH_USER` + `MAESTRO_AUTH_PASSWORD` (Basic Auth for the
+     dashboard — set both before exposing a public domain)
+   - Do **not** set `MAESTRO_PORT` — Railway assigns `$PORT` and routes its
+     healthcheck to it; the conductor reads `$PORT` when `MAESTRO_PORT` is
+     unset. Hardcoding `MAESTRO_PORT` shadows `$PORT` and the healthcheck
+     fails. `MAESTRO_DATA_DIR=/data` and `CLAUDE_CONFIG_DIR=/data/claude`
+     are already baked into the image.
 5. **Public domain**: enable a domain for the service (Railway → Settings →
-   Public Networking). The Hono server listens on `MAESTRO_PORT`.
+   Public Networking) with target port `3000`.
 6. **Verify**: hit `https://<your-domain>/api/health` and confirm a 200.
-
-## Authenticating the Claude Code CLI
-
-ADR-001 commits Maestro to using the local `claude` CLI rather than the
-Anthropic API. Railway's Docker image deliberately does **not** install
-Claude Code — the OAuth flow needs an interactive shell. Two options:
-
-- **Production**: SSH (or use Railway's "Deploy → Shell") into the running
-  container with the volume mounted, install Claude Code, run `claude
-  /login`, and finish the OAuth flow. Repeat after token expiry.
-- **Self-hosted on a VPS** (recommended for the developer's own use): run
-  `pnpm install && pnpm build` on the VPS directly, install Claude Code,
-  authenticate once, then run the conductor under a process supervisor
-  (systemd, pm2, etc.). The Dockerfile is for parity testing and future
-  multi-tenant deploys.
 
 ## Verifying a deploy
 
@@ -61,6 +51,25 @@ The Docker image bakes the build at `/app/dashboard`; outside Docker the
 conductor looks for `MAESTRO_DASHBOARD_DIR`, then the repo-relative
 `packages/dashboard/dist`. Opening `https://maestro.<your-domain>/`
 should render the Overview page with no separate dashboard process.
+
+## Git push credentials
+
+The conductor pushes branches over HTTPS. The Docker image ships a
+system-wide git credential helper that feeds `GITHUB_TOKEN` from the
+environment at push time, so no extra setup is needed on Railway — just
+ensure `GITHUB_TOKEN` is set as a service variable.
+
+Running the conductor **outside Docker** (a bare VPS, `pnpm dev`)? The
+host's own git credential setup handles auth — on macOS that's the
+keychain; on Linux, configure a helper once:
+
+```bash
+git config --global credential.helper \
+  '!f() { test "$1" = get && echo username=x-access-token && echo "password=$GITHUB_TOKEN"; }; f'
+```
+
+Without a helper (and without a token-embedded remote), the worker's
+push fails auth and the session is marked failed before a PR opens.
 
 ## Claude Code bootstrap (one-time per deploy host)
 

--- a/packages/conductor/src/worker.ts
+++ b/packages/conductor/src/worker.ts
@@ -560,6 +560,12 @@ async function runSessionInner(input: InnerInput): Promise<RunSessionOutput> {
 
   // Step 10: PR creation ----------------------------------------------------------
   const baseBranch = project.autonomyConfig.branches.base
+  // The push authenticates via git's credential layer. On a dev machine
+  // the host's own helper supplies the token (e.g. macOS keychain); in the
+  // Docker image a system-wide credential helper feeds GITHUB_TOKEN from
+  // the environment (see Dockerfile + docs/DEPLOYMENT.md). Without one of
+  // those a headless host's push would fail auth — which is the deploy
+  // gotcha this paths around.
   await git.push(['-u', 'origin', branch])
 
   const githubClient =


### PR DESCRIPTION
## Problem
A deployed session failed despite the agent doing good work and all gates passing. The worker's `git push -u origin <branch>` threw an auth error and failed the session **before** opening the PR — the working clone's `origin` is a tokenless HTTPS URL and the Railway container had no git credential helper. (Local dev worked only because the macOS keychain silently supplied the token.) DB signature: `terminationCause=failed, notes=null, branch=null` — the exception path.

## Fix
The Docker image configures a **system-wide git credential helper** that feeds `GITHUB_TOKEN` from the environment at push time. The token never lands on disk, in the image, in a remote URL, or in argv — the helper reads `$GITHUB_TOKEN` at runtime, and only a process whose env carries it (the conductor) gets a usable credential. A sandboxed agent without the token gets an empty password and can't push.

Verified in a built image: `git credential fill` for `github.com` resolves `username=x-access-token` + the env token.

Chose this over:
- configuring `credential.helper` via simple-git (refused by default — `allowUnsafeCredentialHelper` CVE mitigation)
- embedding the token in the push URL (leaks into argv + logs)

Also fixes two stale `docs/DEPLOYMENT.md` bits that misdirect a deploy: the `MAESTRO_PORT=3000` instruction (the `$PORT`-shadowing healthcheck bug from #76) and the claim that the image doesn't bundle Claude Code (it does, ADR-025).

## Test plan
- [x] `pnpm -r test` (141/141), lint clean
- [x] `docker build` + `git credential fill` resolves the token from env in the image
- [ ] Redeploy → trigger a session on aiflowo → PR opens (verifying post-merge)

## Follow-up (separate PR)
The ADR-014 env whitelist is inert — `claude-runner.ts` spawns the agent with `execa(..., { env: claudeEnv() })` but no `extendEnv: false`, so the agent inherits the full conductor env (incl. `GITHUB_TOKEN`). Fixing that needs `extendEnv: false` + adding `CLAUDE_CONFIG_DIR` to the whitelist; handling separately with care.